### PR TITLE
Updates Chapter 5 Section 3, Tomcat

### DIFF
--- a/docs/5/5.2-jenkins.md
+++ b/docs/5/5.2-jenkins.md
@@ -13,7 +13,7 @@ You should already be familiar with using the Jenkins web GUI interface however 
 ## Exercise
 
 1. Setup a fresh Jenkins server.
-2. Enable the Jenkins SSH server *Configure Global Security* / *SSH Server* and set SSHD Port to an unused port such as 2222. You may also need make port accessible to your localhost by port forwarding from your virtual machine or container and opening up the port in the firewall.
+2. Enable the Jenkins SSH server *Configure Global Security* / *SSH Server* and set SSHD Port to an unused port such as 2222. You may also need to make the port accessible to your localhost by port forwarding from your virtual machine or container and opening up the port in the firewall.
 3. Add your public ssh key to your Jenkin user's configuration (*Manage Users* / YOUR USER / *Configure* / *SSH Public Keys*).
 4. Download the [Jenkins' java CLI client](https://jenkins.io/doc/book/managing/cli/) from your local server.
 5. Run the help command `java -jar jenkins-cli.jar -s JENKINS_URL -ssh -user USERNAME help` to look at the available commands.

--- a/docs/5/5.3-tomcat.md
+++ b/docs/5/5.3-tomcat.md
@@ -17,7 +17,9 @@ You can find out more about Tomcat from the [official website](https://tomcat.ap
 Before continuing, make sure you have two separate servers, one running Jenkins, and one running Tomcat.
 
 ## Deploying from Jenkins to Tomcat
-1. Configure two Jenkins jobs, one which builds [spring-petclinic](https://github.com/liatrio/spring-petclinic) and a second which deploys the build artifacts to Tomcat using SCP.
+1. Setup an SSH key to allow Jenkins to connect to Tomcat.
+1. Configure a Jenkins job which builds [spring-petclinic](https://github.com/liatrio/spring-petclinic).
+2. Configure a second job using a shell script to deploy the build artifacts to Tomcat with SCP.
 2. Set up your jobs so that when the build job is complete, the deploy job is triggered automatically.
 3. Visit your Tomcat server and confirm the project deployed correctly. You should be able to see the webapp in your browser.
 
@@ -40,7 +42,6 @@ Discuss the differences between both approaches.
 
 ## Tips
 - Jenkins extends its functionality with plugins, they may help with this section, but you can complete it without any.
-- You will need to setup an SSH key for Jenkins to be able to access your Tomcat server.
 
 # Deliverable
 - A simple pipeline setup with Jenkins capable of delivering an artifact to Tomcat, where you can view the application.

--- a/docs/5/5.3-tomcat.md
+++ b/docs/5/5.3-tomcat.md
@@ -8,7 +8,7 @@ In this section you will learn how to configure Tomcat. Tomcat is an open-source
 </center>
 
 ## Setup Tomcat
-1. Setup a new server based on your golden image.
+1. Setup a new server using on your golden image.
 2. Check that your software is up-to-date, and update anything that's needed.
 3. Install and configure Tomcat to run on your server.
 
@@ -17,9 +17,9 @@ Before continuing, make sure you have two separate servers, one running Jenkins,
 
 ## Deploying from Jenkins to Tomcat
 1. First, verify both servers are running by visiting the URLs of both.
-2. Configure two Jenkins jobs, one which builds [spring-petclinic](https://github.com/liatrio/spring-petclinic) and a second which deploys the build artifacts to Tomcat.
-3. Set up your jobs so that when the build is complete, the deploy job is called automatically.
-4. Visit your Tomcat server and confirm the project deployed correctly. You should be able to find a web page corresponding to the project you built. 
+2. Configure two Jenkins jobs, one which builds [spring-petclinic](https://github.com/liatrio/spring-petclinic) and a second which deploys the build artifacts to Tomcat using SCP.
+3. Set up your jobs so that when the build job is complete, the deploy job is triggered automatically.
+4. Visit your Tomcat server and confirm the project deployed correctly. You should be able to see the webapp in your browser.
 
 ## Extended Exercise
 1. Try changing your setup to use a post build step instead of a second job.
@@ -28,10 +28,9 @@ Before continuing, make sure you have two separate servers, one running Jenkins,
 Consider the benefits and drawbacks of each method you've used.
 
 ## Tips
-- You may need to fork the project you build in order to edit the POM file.
 - Jenkins extends its functionality with plugins, they may help with this section, but you can complete it without any.
 - You will need to setup an SSH key for Jenkins to be able to access your Tomcat server.
 
 # Deliverable
-- A simple pipeline setup with Jenkins capable of delivering an artifact to Tomcat, where you can preview the application.
+- A simple pipeline setup with Jenkins capable of delivering an artifact to Tomcat, where you can view the application.
 - Discuss the benefits of using a tool like Tomcat in software development.

--- a/docs/5/5.3-tomcat.md
+++ b/docs/5/5.3-tomcat.md
@@ -21,11 +21,22 @@ Before continuing, make sure you have two separate servers, one running Jenkins,
 3. Set up your jobs so that when the build job is complete, the deploy job is triggered automatically.
 4. Visit your Tomcat server and confirm the project deployed correctly. You should be able to see the webapp in your browser.
 
-## Extended Exercise
-1. Try changing your setup to use a post build step instead of a second job.
-2. Change your setup again to use a Maven plugin to deploy to Tomcat, as opposed to Jenkins.
+## Applying the Maven Way
 
-Consider the benefits and drawbacks of each method you've used.
+In Chapter 4 we discussed the benefits of convention over configuration. When
+building new jobs it is common to venture away from the Maven Way in
+order to experiment with how it can be built. Once you determine the correct
+process, it is best to codify that process into plugins, allowing you to save
+configuration in version control and increase modularity. In the previous
+exercise we explored deploying our artifact using SCP, however there is another
+way.
+
+1. Read about the [Tomcat Maven Plugin](http://tomcat.apache.org/maven-plugin-2.0/tomcat7-maven-plugin/)
+2. Edit your Maven settings to provide authentication for Tomcat.
+3. Edit your POM to deploy to Tomcat using the given credentials.
+4. Reconfigure your Jenkins job to ensure the plugin runs.
+
+Discuss the differences between both approaches.
 
 ## Tips
 - Jenkins extends its functionality with plugins, they may help with this section, but you can complete it without any.

--- a/docs/5/5.3-tomcat.md
+++ b/docs/5/5.3-tomcat.md
@@ -1,4 +1,4 @@
-# Tomcat :smiley_cat:
+# Tomcat
 In this section you will learn how to configure Tomcat. Tomcat is an open-source Java Servlet container developed by Apache, that provides a Java HTTP web server environment to run and test java code. To find out more about Tomcat, you can browse [here](https://en.wikipedia.org/wiki/Apache_Tomcat).
 
 <center>
@@ -8,27 +8,30 @@ In this section you will learn how to configure Tomcat. Tomcat is an open-source
 </center>
 
 ## Setup Tomcat
-1. Configure a new server similar to the one you did for the Jenkins.
-2. Make sure to take the common practice and update your server with the newest updates before beginning work.
-3. Gather information on requirements to run Tomcat. Think of what type of application Tomcat is and what it may use to run correctly.
-4. Next, create a Tomcat user and Tomcat group.
-5. Finally, install Tomcat on your server.
+1. Setup a new server based on your golden image.
+2. Check that your software is up-to-date, and update anything that's needed.
+3. Install and configure Tomcat to run on your server.
 
-# Before moving on
-Before continuing, make sure you have two separate servers, with a single application on both.
-1. The first server should have Jenkins installed and properly running on its own.
-2. The second server should have Tomcat installed and properly running. Refer to the top of this guide if not completed.
+### Before moving on
+Before continuing, make sure you have two separate servers, one running Jenkins, and one running Tomcat.
 
 ## Deploying from Jenkins to Tomcat
 1. First, verify both servers are running by visiting the URLs of both.
-2. There are two ways you can choose to connect the two applications.
-    1. You can add a post-build action that deploys to Tomcat by the use of a Jenkins plugin or the use of [SCP](https://en.wikipedia.org/wiki/Secure_copy).
-    2. You can create a job that specifically deploys to Tomcat. (Best option because it builds modularity into your pipeline).
-3. If you went with the first option you first need to create a new user on the Tomcat server and give it sudoers permissions.
-4. Create a rsa keypair between the Jenkins server and Tomcat server.
-5. Next, you need to configure the job that you want to deploy to Tomcat by adding a post build action and utilizing the Secure Copy Protocol.
-6. Browse to Tomcats webapps directory and look for your deployed project. If empty, consider a few things such as permissions, like who has the ability to write to this folder.
+2. Configure two Jenkins jobs, one which builds [spring-petclinic](https://github.com/liatrio/spring-petclinic) and a second which deploys the build artifacts to Tomcat.
+3. Set up your jobs so that when the build is complete, the deploy job is called automatically.
+4. Visit your Tomcat server and confirm the project deployed correctly. You should be able to find a web page corresponding to the project you built. 
+
+## Extended Exercise
+1. Try changing your setup to use a post build step instead of a second job.
+2. Change your setup again to use a Maven plugin to deploy to Tomcat, as opposed to Jenkins.
+
+Consider the benefits and drawbacks of each method you've used.
+
+## Tips
+- You may need to fork the project you build in order to edit the POM file.
+- Jenkins extends its functionality with plugins, they may help with this section, but you can complete it without any.
+- You will need to setup an SSH key for Jenkins to be able to access your Tomcat server.
 
 # Deliverable
-- A working Jenkins server with a job that is able to deliver an artifact to Tomcat's server in which you can get a preview of the application.
-- Discussion of the benefits of using a tool like Tomcat in software development.
+- A simple pipeline setup with Jenkins capable of delivering an artifact to Tomcat, where you can preview the application.
+- Discuss the benefits of using a tool like Tomcat in software development.

--- a/docs/5/5.3-tomcat.md
+++ b/docs/5/5.3-tomcat.md
@@ -18,10 +18,12 @@ Before continuing, make sure you have two separate servers, one running Jenkins,
 
 ## Deploying from Jenkins to Tomcat
 1. Setup an SSH key to allow Jenkins to connect to Tomcat.
-1. Configure a Jenkins job which builds [spring-petclinic](https://github.com/liatrio/spring-petclinic).
-2. Configure a second job using a shell script to deploy the build artifacts to Tomcat with SCP.
-2. Set up your jobs so that when the build job is complete, the deploy job is triggered automatically.
-3. Visit your Tomcat server and confirm the project deployed correctly. You should be able to see the webapp in your browser.
+2. Configure a Jenkins job which builds [spring-petclinic](https://github.com/liatrio/spring-petclinic).
+3. Configure a second job that deploys the build artifacts to Tomcat with SCP using either:
+  - A shell script
+  - A Jenkins plugin
+4. Set up your jobs so that when the build job is complete, the deploy job is triggered automatically.
+5. Visit your Tomcat server and confirm the project deployed correctly. You should be able to see the webapp in your browser.
 
 ## Applying the Maven Way
 
@@ -39,9 +41,6 @@ way.
 4. Reconfigure your Jenkins job to ensure the plugin runs.
 
 Discuss the differences between both approaches.
-
-## Tips
-- Jenkins extends its functionality with plugins, they may help with this section, but you can complete it without any.
 
 # Deliverable
 - A simple pipeline setup with Jenkins capable of delivering an artifact to Tomcat, where you can view the application.

--- a/docs/5/5.3-tomcat.md
+++ b/docs/5/5.3-tomcat.md
@@ -1,5 +1,6 @@
 # Tomcat
-In this section you will learn how to configure Tomcat. Tomcat is an open-source Java Servlet container developed by Apache, that provides a Java HTTP web server environment to run and test java code. To find out more about Tomcat, you can browse [here](https://en.wikipedia.org/wiki/Apache_Tomcat).
+In this section you will learn how to configure Tomcat. Tomcat is an open-source Java Servlet container developed by Apache, that provides a Java HTTP web server environment to run and test java code.
+You can find out more about Tomcat from the [official website](https://tomcat.apache.org/) and [wikipedia page](https://en.wikipedia.org/wiki/Apache_Tomcat).
 
 <center>
 
@@ -16,10 +17,9 @@ In this section you will learn how to configure Tomcat. Tomcat is an open-source
 Before continuing, make sure you have two separate servers, one running Jenkins, and one running Tomcat.
 
 ## Deploying from Jenkins to Tomcat
-1. First, verify both servers are running by visiting the URLs of both.
-2. Configure two Jenkins jobs, one which builds [spring-petclinic](https://github.com/liatrio/spring-petclinic) and a second which deploys the build artifacts to Tomcat using SCP.
-3. Set up your jobs so that when the build job is complete, the deploy job is triggered automatically.
-4. Visit your Tomcat server and confirm the project deployed correctly. You should be able to see the webapp in your browser.
+1. Configure two Jenkins jobs, one which builds [spring-petclinic](https://github.com/liatrio/spring-petclinic) and a second which deploys the build artifacts to Tomcat using SCP.
+2. Set up your jobs so that when the build job is complete, the deploy job is triggered automatically.
+3. Visit your Tomcat server and confirm the project deployed correctly. You should be able to see the webapp in your browser.
 
 ## Applying the Maven Way
 

--- a/docs/5/5.4-nexus.md
+++ b/docs/5/5.4-nexus.md
@@ -12,78 +12,14 @@ versions of Snapshots and Releases.
 
 </center>
 
-# Exercise 1 - Nexus
+# Setup Nexus
 
-In this exercise we will be setting up a new Nexus server and configuring Jenkins to deploy artifacts to it.
+1. Install Nexus on a new sever.
+2. Configure a Jenkins [spring-petclinic](https://github.com/liatrio/spring-petclinic) job to deploy SNAPSHOT artifacts to your Nexus.
 
-1. Install a fresh nexus server (refer to you notes for Chapter 2)
-2. Configure your Jenkins petclinic job to deploy SNAPSHOT artifacts to your Nexus.
-3. Document a step-by-step guide to show your experience.
+Confirm that your artifact was deployed.
 
-### Deliverable
-
-  Be able to deploy an artifact from Jenkins onto Nexus and confirm that it had been deployed.
-
-# Exercise 2 - Jenkins to Nexus
-
-### Overview
-The following steps are on deploying artifacts from Nexus to Jenkins. This guide does not specify how to deploy an artifact from Nexus to a target (such as Tomcat).
-
-### Prerequisites:
-- Jenkins installed on a server.
-- Nexus Installed on a server.
-- Git repository that contains a Java project
-
-1. Set up Nexus
-  - Sign in as an Admin user and create Users for Nexus if necessary.
-2. Set up Jenkins
-  - Create a Maven Jenkins job and use your fork of [spring-petclinic](//github.com/liatrio/spring-petclinic) for git polling
-  - Set up the Maven Build information with your `pom.xml` from your project
-  - We will need to store our password and admin info for Nexus saved onto the server
-    - Create file settings.xml and store it in /var/lib/jenkins/.m2/
-      ```
-      <!--Example of username/password for the xml-->
-
-      <settings>
-        <servers>
-          <server>
-            <id>snapshots</id>
-            <username>snapshots</username>
-            <password>thePassword</password>
-          </server>
-          <server>
-            <id>deployment</id>
-            <username>deployment</username>
-            <password>thePassword</password>
-          </server>
-        </servers>
-      </settings>
-      ```
-  - Test if our Jenkins instance is correctly doing `mvn deploy` to our Nexus repository.
-3. Setting up the project
-  - We need to put all the Nexus info into the pom file under the _distributionManagement_ tag. This is an example:
-    ```
-    <distributionManagement>
-      <snapshotRepository>
-        <id>snapshots</id>
-        <url>http://ip-172-31-25-3.us-west-2.compute.internal:8081/nexus/content/repositories/snapshots/</url>
-      </snapshotRepository>
-      <repository>
-        <id>deployment</id>
-        <url>http://ip-172-31-25-3.us-west-2.compute.internal:8081/nexus/content/repositories/releases/</url>
-      </repository>
-    </distributionManagement>
-    ```
-  - There are 2 types of Nexus repositories, _snapshots_ and _deployments_. Save these changes and commit it back to your repository.
-4. Build the project
-  - Build the Jenkins job and confirm that the artifact was successfully deployed.
-5. See the artifact in Nexus
-  - Go to the nexus GUI in a web browser at either (your-ip-address):8081/nexus or (your-ip-address):8081 and confirm that your artifact has been deployed to Nexus.
-
-### Deliverable
-Have a Jenkins job build a project from a code repository and deploy that artifact to Nexus.
-
-# Exercise 3 - Nexus to Tomcat
+# Retrieving Artifacts from Nexus
 
 0: Basic Overview:
   1. Create an ssh key

--- a/docs/5/5.4-nexus.md
+++ b/docs/5/5.4-nexus.md
@@ -1,9 +1,8 @@
 # Nexus
 
-Nexus is a repository manager for Java artifacts and is useful for keeping track of
-versions of Snapshots and Releases. Previously in the Bootcamp, we've deployed artifacts to Nexus as a final step in our pipeline. 
-However, in production deploying to Nexus would serve as an intermediate step with other tools using it down the pipeline.
-In this section we'll be setting up a pipeline using Nexus as a repository for our build artifacts. 
+A software artifact is the product produced by software development, often used to mean compiled executables or packaged code. Just like how source code is generally stored in repositories and version controlled, artifacts are also stored in repositories where their versions are tracked.
+
+Nexus is one such repository manager which stores artifacts. Previously in the Bootcamp, we've used it with Maven as the ultimate destination of our deployments. However, if you're storing artifacts, it's obvious you might also like to use them later. In this section we'll use Nexus as an intermediate step, with the artifacts stored there being used later in our pipeline.
 
 <center>
 
@@ -13,39 +12,18 @@ In this section we'll be setting up a pipeline using Nexus as a repository for o
 
 # Setup Nexus
 
-1. Install Nexus on a new sever.
+1. Install Nexus on a new server.
 2. Configure a Jenkins [spring-petclinic](https://github.com/liatrio/spring-petclinic) job to deploy SNAPSHOT artifacts to your Nexus.
 
 Confirm that your artifact was deployed.
 
 # Retrieving Artifacts from Nexus
 
-0: Basic Overview:
-  1. Create an ssh key
-  2. In the "Manage Jenkins" section of your Jenkins instance, create an ssh server "Tomcat" using the info from your Tomcat instance and the private key of the key you created
-  3. Create a "tomcat-deploy" job in Jenkins
-  4. Have this "tomcat-deploy" job execute an ssh command from your newly created tomcat server that will deploy a .war file to your Tomcat instance
-
-1: Creating an SSH key
-  1. In a directory of your choice run the ssh-keygen command
-  2. Ensure that you are familiar with the workings of private keys, and know how to use them properly
-
-2: Create a Tomcat server in "Manage Jenkins"
-
-  In your Jenkins job, fill in the SSH Server section with your Tomcat server info and the private key you created.
-
-3: Create a tomcat-deploy job in Jenkins
-
-  By this point you are familiar with the process of creating a job in Jenkins. Make one which will run an SSH command on your tomcat server. It is smarter to do this instead of running a post-build action SSH command because you can make this job run on whatever triggers you specify, rather than after a certain job.
-
-4: Execute a command while SSH'd into your Tomcat server
-
-  In the "build" section of your tomcat-deploy job's configurations, select "send files or execute commands over SSH". Select the server you recently created in your "Manage Jenkins" settings in the dropdown box on top.
-
-On your own, research and find a good command that will get the .war file from your nexus and deploy it to the spot that you want. A good place to start your research is at the link below:
-
-http://stackoverflow.com/questions/22569710/how-can-i-automatically-deploy-a-war-from-nexus-to-tomcat
+1. Install the [Publish Over SSH](https://wiki.jenkins.io/display/JENKINS/Publish+Over+SSH+Plugin) Jenkins plugin.
+2. Setup an SSH key pair between your Tomcat server and Jenkins. 
+3. Create a new Jenkins job that will connect to your Tomcat server, then download a .war file from Nexus.
+4. Nexus stores metadata for builds separate from the artifacts themselves. Use this metadata and add a script to your deploy job so that it downloads the newest petclinic artifact from Nexus.
 
 ### Deliverable
 
-  Have a Jenkins job deploy an artifact from a repository to Nexus, then deploy the artifact from Nexus to Tomcat.
+  Have a Jenkins job deploy an artifact to Nexus, then deploy the artifact from Nexus to Tomcat.

--- a/docs/5/5.4-nexus.md
+++ b/docs/5/5.4-nexus.md
@@ -1,10 +1,9 @@
 # Nexus
 
-In this step we will run the steps below. Be sure to keep enough notes to create
-a step-by-step guide showing your experience through this section. Nexus is a
-repository manager for Java artifacts and is useful for keeping track of
-versions of Snapshots and Releases.
-
+Nexus is a repository manager for Java artifacts and is useful for keeping track of
+versions of Snapshots and Releases. Previously in the Bootcamp, we've deployed artifacts to Nexus as a final step in our pipeline. 
+However, in production deploying to Nexus would serve as an intermediate step with other tools using it down the pipeline.
+In this section we'll be setting up a pipeline using Nexus as a repository for our build artifacts. 
 
 <center>
 


### PR DESCRIPTION
Makes some formatting changes, as well as rewriting the exercise. Apprentices are now asked to set up multiple Jenkins jobs, instead of it being optional. Extended exercise options are included however, which are deploying within a single Jenkins job and deploying using a Maven plugin.