### PR TITLE
Resets scrollbar to top of page on load

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,7 @@
       name: '',
       repo: '',
       loadSidebar: true,
+      auto2top: true,
       search: 'auto', // default
       plugins: [
         EditOnGithubPlugin.create(


### PR DESCRIPTION
Previously, when a new section is loaded the scrollbar isn't reset to the top of the page. 

This PR corrects that issue.