### PR TITLE
Fix: Broken links in the main README.md and in the Jira section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![liatrio](docs/img/Liatrio-icon.png)
+
+![Liatrio Logomark](docs/img/favicon.svg ':size=150x150 :class=logo')
 # Liatrio's DevOps Bootcamp
 
 Welcome! You must be here because you're interested in DevOps. Don't worry, we'll explain that right away! Let's introduce some goals and expectations first, though.

--- a/docs/4-software-development-practices/4.2-jira.md
+++ b/docs/4-software-development-practices/4.2-jira.md
@@ -92,7 +92,7 @@ Jira refers to tickets as *issues.* Although there are various ticket types out 
 
 ### Content
 
- - Make sure the each ticket has [Acceptance Criteria](4/4.1.4-stories.md)
+ - Make sure the each ticket has [Acceptance Criteria](4-software-development-practices/4.1.4-stories.md)
  - A Definition of Done (DOD) should be located in the summary of the ticket
  - The summary should be updated with any relevant links
  - Solutions should be easily repeatable by anyone


### PR DESCRIPTION
The main README.md's broken link had to do with the main Liatrio logo. The file that it was showing was removed or renamed so I copied the logo line from the docs/README.md file.

The broken link in the Jira section was a link to the Agile Stories section. Before it would just link to a 404 page, but now it should be fixed.