### PR TITLE
Pycast link fix

### DIFF
--- a/docs/1-introduction/1.4-external-resources.md
+++ b/docs/1-introduction/1.4-external-resources.md
@@ -20,9 +20,9 @@ At Liatrio, we're always sharing fun or informative learning resources we come a
  - [DevOps Cafe](http://devopscafe.org)
 
 ## Videos
- - [Spotify Engineering Culture - Part 1](https://www.youtube.com/watch?v=4GK1NDTWbkY)
+ - [Spotify Engineering Culture - Part 1](https://www.youtube.com/watch?v=Yvfz4HGtoPc)
     - In Spotify's Engineering Culture Part 1, you are introduced to some of the key reasons why Spotify is as successful as it is. Over at Spotify they run on loose agile principles, and form squads that are loosely coupled but tightly aligned. This idea allows employees more freedom to work on things they are passionate about and leads to more self motivation to produce the best product possible. At Spotify they push new features and updates out in small frequent releases to get feedback quicker and make changes as needed to fit customers needs. One of their main ideas to release products is known as a release train, this allows new features to be released while also pushing unfinished releases to ensure there is no conflicts between the multiple updates but then hide those features that aren't finished through a toggle option.
- - [Spotify Engineering Culture - Part 2](https://www.youtube.com/watch?v=X3rGdmoTjDc)
+ - [Spotify Engineering Culture - Part 2](https://www.youtube.com/watch?v=vOt4BbWLWQw)
     - In Spotify's Engineering Culture Part 2, we learn about Spotifys culture of trying to fail the fastest. The idea behind this is the quicker you fail the quicker you can learn and improve. This idea also allows continuous improvement, something they strive for by always updating their products and analyzing the customers views on these updates. Once the feature is then analyzed, Spotify can then quickly go in and tweak the new feature to fit the users needs and provide the best product to the customer and dump those that did not work.
  - [YOW! Nights March 2016 Martin Fowler - Infrastructure As Code](https://www.youtube.com/watch?v=ueAef9tNUck)
 
@@ -30,8 +30,8 @@ At Liatrio, we're always sharing fun or informative learning resources we come a
  - [The Phoenix Project](https://itrevolution.com/book/the-phoenix-project/)
  - [Continuous Delivery](https://martinfowler.com/books/continuousDelivery.html)
  - [The Goal](http://www.amazon.com/The-Goal-Process-Ongoing-Improvement/dp/0884271951?ie=UTF8&camp=1789&creative=9325&creativeASIN=0884271951&linkCode=as2&tag=itrevpre-20)
- - Release It
- - Lean Enterprise
+ - [Release It](https://www.amazon.com/Release-Production-Ready-Software-Pragmatic-Programmers/dp/0978739213)
+ - [Lean Enterprise](https://www.amazon.com/Lean-Enterprise-Performance-Organizations-Innovate/dp/1449368425)
  - [Accelerate](https://itrevolution.com/book/accelerate/)
  - [The Unicorn Project](https://itrevolution.com/book/the-unicorn-project/)
  - [Phippy and Friends](https://www.cncf.io/phippy/)

--- a/docs/1-introduction/1.4-external-resources.md
+++ b/docs/1-introduction/1.4-external-resources.md
@@ -15,7 +15,7 @@ At Liatrio, we're always sharing fun or informative learning resources we come a
  - [Julia Evans](https://jvns.ca/)
 
 ## Podcasts
- - [PodCTL](https://blog.openshift.com/tag/podctl/)
+ - [PodCTL](https://www.podctl.com/)
  - [Kubernetes Podcast from Google](https://kubernetespodcast.com/)
  - [DevOps Cafe](http://devopscafe.org)
 


### PR DESCRIPTION
Altered the links for Spotify Engineering Culture - Part 1 & 2 videos.
Part 2's link was private and no longer viewable.
Part 1's link was changed to match the same YouTube account of Part 2.

Added links to "Release It" and "Lean Enterprise" since both did not currently have links.