### PR TITLE
Update 3.3.5-aci.md

### DIFF
--- a/docs/3-cloud-computing/3.3.5-aci.md
+++ b/docs/3-cloud-computing/3.3.5-aci.md
@@ -85,7 +85,7 @@ docker push $DOCKER_SERVER/aci-bootcamp:v1
 SP_NAME="http://YOUR_NAME-devops-bootcamp-acr"
 REGISTRY_ID=$(az acr show --name $REGISTRY_NAME --query id --output tsv)
 DOCKER_PASSWORD=$(az ad sp create-for-rbac --name $SP_NAME --scopes $REGISTRY_ID --role acrpull --query password --output tsv)
-DOCKER_USERNAME=$(az ad sp show --id $SP_NAME  --query appId --output tsv)
+DOCKER_USERNAME=$(az ad sp list --display-name $SP_NAME --query '[0].appId' --output tsv)
 ```
 
 ?> You need owner role or equivalent permissions on a subscription to create service principals. If you don't have access, you may want to do this short lab in your free Microsoft account.


### PR DESCRIPTION
Grabbing DOCKER_USERNAME from "az ad sp show" does not work since it requires the "--id" flag to be in format "00000000-0000-0000-0000-000000000000" or "api://myapp" which the current version is not.  It instead uses the display name of our service principle, which "az ad sp list" is able to use with flag "--display-name"