### PR TITLE
fixed 'important icon' and updated 2.5.1

### DIFF
--- a/2-virtual-machines-containers/2.5.1-docker-compose.md
+++ b/2-virtual-machines-containers/2.5.1-docker-compose.md
@@ -2,7 +2,7 @@
 
 [Docker Compose](https://docs.docker.com/compose/) manages multiple Docker containers using a single `docker-compose.yml` configuration file. With it, you can build and run an entire environment using just the `docker-compose up` command. Sound familiar to any other tools you've used lately? The configuration options correlate directly with arguments used with the Docker CLI which makes it an easy tool to start using as you're getting familiar with Docker. It lacks features needed for complicated environments but has some very useful use cases.
 
-  ?> As of Docker Desktop version 3.4.0, the new [Compose V2](https://docs.docker.com/compose/cli-command/) integrates compose commands into the Docker CLI. These commands can be used by simply replacing the dash (-) with a space. Both `docker-compose` and `docker compose` can be used after installing Docker Desktop, no longer requiring a separate installation.
+?> As of Docker Desktop version 3.4.0, the new [Compose V2](https://docs.docker.com/compose/cli-command/) integrates compose commands into the Docker CLI. As of June 2023, the `docker-compose` command will no longer be supported on Docker Desktop and will be replaced with `docker compose` (the '-' is replaced with a space). The command can be used after installing Docker Desktop, no longer requiring a separate installation.
 
 ## Use Cases
 


### PR DESCRIPTION
- There was an issue with an icon not displaying in an important section.
- Update that section (2.5.1) with details about Docker Desktop not supporting Compose V1 in June.