### PR TITLE
docs: Updates steps and repo in 3.2.1 so things work.

### DIFF
--- a/3-cloud-computing/3.2.1-s3-cloudfront.md
+++ b/3-cloud-computing/3.2.1-s3-cloudfront.md
@@ -6,26 +6,20 @@ In this section we will run through several exercises which showcase AWS S3 and 
 
 > Amazon Simple Storage Service (Amazon S3) is the largest and most performant, secure, and feature-rich object storage service. With Amazon S3, organizations of all sizes and industries can store any amount of data for any use case, including applications, IoT, data lakes, analytics, backup and restore, archive, and disaster recovery. -- [Amazon S3](https://aws.amazon.com/s3/)
 
-For this exercise we're hosting a static HTML website using AWS S3. We will be using a simple react based application called [DevOps Knowledge Share](https://github.com/liatrio/devops-knowledge-share-dob-ui) to create our sample website. This small scale project is owned and managed here at Liatrio and its intended purpose is to show our clients during dojos the power of CI/CD. It is a simple application that has a frontend (ui) and backend (api) but, we will only be using the ui for now. Feel free to try creating and substituting with a different template or project.
+For this exercise we're hosting a static HTML website using AWS S3. We will be using a simple react based application called [S3 Realworld UI DOB](https://github.com/liatrio/s3-realworld-ui-dob) to create our sample website. Feel free to try creating and substituting with a different template or project.
 
 **Requirements**
 
 - You will need to have npm installed to perform this exercise.
 
 1. Clone the sample project.
-2. Change to the template directory.
-3. Generate the HTML for the template.
+2. Navigate to the project directory directory. Run `npm install` to fetch all project dependencies.
+3. Generate the HTML for the templates with `npm run build`
+4. Run `npm start` and open http://localhost:3000 to confirm that the website is set up correctly.
+5. Create the S3 Bucket. Replace *YOUR_NAME* with your name and *PROFILE_NAME* with the name of the AWS cli profile you set up. Make sure to replace *PROFILE_REGION* with the region you configured you AWS cli profile to talk to (run `cat ~/.aws/config` to see what your cli is configured to).
 
 ```
-npm install
-npm run build
-```
-
-4. **Optional** Run `npm start` and open http://localhost:4100 to confirm that the website is set up.
-5. Create the S3 Bucket. Replace *YOUR_NAME* with your name and *PROFILE_NAME* with the name of the AWS cli profile you set up. The region requires a location constraint to be specified because it is not in us-east-1.
-
-```
-aws-vault exec PROFILE_NAME -- aws s3api create-bucket --bucket YOUR_NAME-dob-react --create-bucket-configuration LocationConstraint=us-west-2
+aws-vault exec PROFILE_NAME -- aws s3api create-bucket --bucket YOUR_NAME-dob-react --create-bucket-configuration LocationConstraint=PROFILE_REGION.
 ```
 
 6. Verify that the S3 bucket was created in the AWS console.
@@ -35,26 +29,27 @@ aws-vault exec PROFILE_NAME -- aws s3api create-bucket --bucket YOUR_NAME-dob-re
 aws-vault exec PROFILE_NAME -- aws s3 website s3://YOUR_NAME-dob-react --index-document index.html --error-document 404.html
 ```
 
-8. Add tags to the S3 Bucket.
+8. Add tags to the S3 Bucket. While tagging resources is an optional feature in AWS. It is an important organization habit to get into.
 
 ```
 aws-vault exec PROFILE_NAME -- aws s3api put-bucket-tagging --bucket YOUR_NAME-dob-react --tagging 'TagSet=[{Key=Client,Value=Internal},{Key=Project,Value=DOB},{Key=Environment,Value=Demo},{Key=Application,Value=React},{Key=Owner,Value=YOUR_NAME}]'
 ```
 
 9. Verify the tags where created in the AWS console.
-10. Upload the contents of the *build/* folder, which contains the HTML generated from the template, to our S3 bucket. The ACL flag specifies that this content will be readable by the public, which allows people visiting the website to view it.
+10. Upload the contents of the *build/* folder, which contains the HTML generated from the template, to our S3 bucket.
 
 ```
-aws-vault exec PROFILE_NAME -- aws s3 sync build/ s3://YOUR_NAME-dob-react --acl public-read
+aws-vault exec PROFILE_NAME -- aws s3 sync build/ s3://YOUR_NAME-dob-react
 ```
+11. Before you website will be visible to the outside world you need to allow outside traffic to access your bucket. AWS manages access control to S3 buckets via [Bucket Policies](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html). Read about bucket policies and add a policy to allow public read access. 
 
-11. Navigate to http://[your-bucket-name].s3-website-us-west-2.amazonaws.com to confirm that all steps were followed properly.
+12. Navigate to your buckets public DNS name to confirm that all steps were followed properly.
 
 ![](img3/front_page.webp ":class=img-shadow-center")
 
 ### Deliverable for Consultants
 
-1. Comprehend the role of S3 in enterprises
+1. Discuss how enterprise applications might leverage S3. 
 
 ## Create a Web Distribution for your S3 Website using CloudFront
 

--- a/3-cloud-computing/3.2.1-s3-cloudfront.md
+++ b/3-cloud-computing/3.2.1-s3-cloudfront.md
@@ -43,7 +43,7 @@ aws-vault exec PROFILE_NAME -- aws s3 sync build/ s3://YOUR_NAME-dob-react
 ```
 11. Before you website will be visible to the outside world you need to allow outside traffic to access your bucket. AWS manages access control to S3 buckets via [Bucket Policies](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html). Read about bucket policies and add a policy to allow public read access. 
 
-12. Navigate to your buckets public DNS name to confirm that all steps were followed properly.
+12. Navigate to your buckets public DNS name to confirm that all steps were followed properly (Look for a section called **Static website hosting** on your S3 bucket **Policy** tab).
 
 ![](img3/front_page.webp ":class=img-shadow-center")
 


### PR DESCRIPTION
The main change here is from the previously linked (and rather bloated) internal repo devops-knowledge-share-ui. For a lesson on hosting a static website first it did not work and additionally it was overly complex leading to confusion. This branch also addressed some typos and poor assumptions that the previous steps made. This branch also updates the S3 bucket permissions away from ACL rules (deprecated) and to Bucket Policies.