### PR TITLE
fix: fixes alt syntax for liatrio image in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <center>
 
-  ![Liatrio Logomark](img/favicon.svg ':size=150x150 :class=logo' alt="Liatrio image; light mode")
+  ![Liatrio Logomark](img/favicon.svg ':size=150x150 :class=logo :alt= Liatrio image')
 
 # Liatrio's DevOps Bootcamp
 


### PR DESCRIPTION
fixes alt syntax for liatrio image in `README.md`