### PR TITLE
fixing image pathing regarding docsify

### DIFF
--- a/docs/4-software-development-practices/4.3.2-git.md
+++ b/docs/4-software-development-practices/4.3.2-git.md
@@ -70,11 +70,11 @@ There are three states of changed files within Git. Newly created files will be 
 
 At any point in time, use `git status` to see the state of changed files within Git. It will tell you which files are in which state and provide helpful color-coded guides, while provided instructions on what you can do next.
 
-![Git Changes](/img/git-changes.webp ':class=img-shadow')
+![Git Changes](../../img/git-changes.webp ':class=img-shadow')
 
 The staging area is a temporary location in Git that allows you to continue making changes to the working directory. To add untracked files or unstaged changes to staging use `git add FILENAME`. When engineers are ready to attach their changes to version control, they will make a meaningful commit from the staging area using `git commit`, resulting in a clear, distinct moment in time reflecting a unique version. Remember that files must be added to the staging area before committing them.
 
-![Git Staging](/img/git-staging.webp ':class=img-shadow')
+![Git Staging](../../img/git-staging.webp ':class=img-shadow')
 
 ?> When adding files to staging you can specify a directory to add all new or changes files in that directory. Always use `git status` after adding a folder to avoid accidentally add hidden or unwanted files.
 


### PR DESCRIPTION
Fixing pathing in regards to how docsify interprets the image path for section 4.3.2

