### PR TITLE
4.5.5 - Remove Jenkins and replace with GitHub Actions

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,6 +10,7 @@
         "AWSCLIV",
         "azurerm",
         "blaa",
+        "bootcamp",
         "boto",
         "Brolliar",
         "burnup",
@@ -73,7 +74,7 @@
         "pvcs",
         "Qube",
         "reate",
-        "SARIF"
+        "SARIF",
         "schedulable",
         "Schreiber",
         "SCTP",

--- a/.cspell.json
+++ b/.cspell.json
@@ -10,7 +10,6 @@
         "AWSCLIV",
         "azurerm",
         "blaa",
-        "bootcamp",
         "boto",
         "Brolliar",
         "burnup",

--- a/docs/4-software-development-practices/4.5.5-test-automation.md
+++ b/docs/4-software-development-practices/4.5.5-test-automation.md
@@ -4,36 +4,43 @@ docs/4-software-development-practices/4.5.5-test-automation.md:
   estReadingMinutes: 5
   exercises:
     -
-      name: Create a Jenkins Pipeline to test Go project
-      description: Create a Jenkins server via an existing Dockerfile, add Go as a dependency to the Image. On the Jenkins instance point to your fork of the Bootcamp with Go Unit Tests. Create a pipeline that builds and tests your fork.
+      name: Create a GitHub Action to test a Go project
+      description: Create a GitHub Action that will run Unit Tests when a change is pushed
       estMinutes: 180
       technologies:
-      - Jenkins
-      - Docker
+      - GitHub Actions
       - Go
 ---
 
 # Automated Testing
 
-Automated testing is a crucial step to ensure code quality because developed tests are guaranteed to run once new source code is committed. Jenkins is a tool that can help us leverage our tests in a build step. With a testing stage in Jenkins, code quality can be ensured by automatically running the tests that have been written. If tests fail, the build can be marked as unstable and deployment will not occur.
+Automated testing is a crucial step to ensure code quality because developed tests are guaranteed to run once new source code is committed. GitHub Actions is a tool that can help us leverage our tests in a build step. With a testing stage in GitHub Actions, code quality can be ensured by automatically running the tests that have been written. If tests fail, the build can be marked as unstable and deployment will not occur.
 
-## Exercise
+?> If you want to test the creation or alteration of a GitHub workflow before committing it, you can use a tool called [ACT](https://github.com/nektos/act)
 
-1. Locate the Jenkins Dockerfile created in the container section of the bootcamp.
-2. Edit this Dockerfile to add a Go installation to the image.
-3. Create a Freestyle Project that will point to your completed Go Unit Testing exercise from your fork of the Bootcamp.
+## Exercise 1
 
-?>Note: After pointing to your forked repo in Jenkins, you will need to get the path to the Go exercises in the build step
+1. Create a new workflow, `test`, like you did for the `getting-started` workflow in the `GitHub Actions` section of the bootcamp.
+2. Set up this workflow to run whenever code changes are pushed to any branch of your repository
+3. Create jobs for the workflow:
+    * `Setup` - Setup the Go Language
+    * `Test` - Run your Unit Tests, make sure this job depends on the `Setup` job
+4. Commit and push the changes
+5. Go to the Actions tab on your repository fork and verify that `test` workflow ran successfully.
 
-4. Add a build step for testing your exercise.
-5. Add a build step to build the exercise.
-6. Build the Jenkins job and confirm the job has run the tests and the build was successful.
+## Exercise 2
 
-## Multi-Stage Dockerfiles
+1. Open up your `getting-started` workflow that you created in the `GitHub Actions` section of the bootcamp.
+2. Edit this workflow to include the `Test` and `Setup` jobs you created in Exercise 1 as part of this workflow
+3. Alter the existing `simple` job to depend on the `Test` job completing successfully.
+4. Commit and push the changes to your `getting-started` workflow.
+5. Go to the Actions tab on your repository fork and verify that `build` workflow ran successfully.
 
-When having a containerized application, it is a good idea to have a multi-stage Dockerfile to reduce the size and space taken up by the resulting image. In a multi-stage Dockerfile you can implement testing into its own stage. With this strategy, all of the dependencies needed for testing are left in that stage and the runtime stage will only be populated with the necessary build artifacts.
+## Exercise 3 - Badges
+
+1. Update the `README.md` to include a workflow status badge for your `test` workflow.
 
 # Deliverables
 
-* Discuss the positives of having your testing built into an automation tool such as Jenkins
-* Discuss the benefits of having a testing stage in a Dockerfile
+* Discuss the positives of having your testing built into an automation tool such, as GitHub Actions
+* Discuss the benefits of having workflow badges on your projects

--- a/docs/README.md
+++ b/docs/README.md
@@ -483,16 +483,11 @@ docs/4-software-development-practices/4.5.5-test-automation.md:
   category: Software Quality
   estReadingMinutes: 5
   exercises:
-    - name: Create a Jenkins Pipeline to test Go project
-      description: >-
-        Create a Jenkins server via an existing Dockerfile, add Go as a
-        dependency to the Image. On the Jenkins instance point to your fork of
-        the Bootcamp with Go Unit Tests. Create a pipeline that builds and tests
-        your fork.
+    - name: Create a GitHub Action to test a Go project
+      description: Create a GitHub Action that will run Unit Tests when a change is pushed
       estMinutes: 180
       technologies:
-        - Jenkins
-        - Docker
+        - GitHub Actions
         - Go
 docs/4-software-development-practices/4.5.6-sonarqube.md:
   category: Software Quality


### PR DESCRIPTION
As the title says.  It also enhances the exercises a bit and links them up with the upcoming GitHub chapter