### PR TITLE
2.3 - Remove Jenkins, replace with GitHub Actions

### DIFF
--- a/docs/2-virtual-machines-containers/2.3-managing-infrastructure.md
+++ b/docs/2-virtual-machines-containers/2.3-managing-infrastructure.md
@@ -4,34 +4,26 @@ docs/2-virtual-machines-containers/2.3-managing-infrastructure.md:
   estReadingMinutes: 10
   exercises:
     -
-      name: Jenkins and Artifactory on VMs
-      description: Create VMs from your golden image. On one VM install Jenkins and configure workflow to build Spring’s PetClinic. On the other VM install and configure Artifactory. Configure these VMs so they can communicate and create another workflow that pushes the build artifact from the Jenkins server to Artifactory
+      name: Artifactory on VMs
+      description: Create a VM from your golden image and install and configure Artifactory and deploy an artifact to that VM from a GitHub Action
       estMinutes: 390
       technologies:
       - Vagrant
       - CentOS
-      - Jenkins
+      - GitHub Actions
       - Artifactory
+      - Ngrok
 ---
 
 # Managing Infrastructure
 
-In this section, you will be taking what you've learned about virtual machines to build on top of your Golden Image and deploy servers to create a simple software delivery environment. We will cover the tools used in this section in greater detail later in the Bootcamp but for now here are some basic definitions to help you understand the environment will be creating.
-
-## Jenkins
-
-  Jenkins is a build automation server that manages and controls software delivery processes throughout the entire life cycle. It orchestrates tasks including build, test, package, staging, deployment, static code analysis.
-
-![jenkins image](img2/jenkins.svg ':size=226x312 :class=icon :alt= jenkins image')
-
-- A leading open source continuous integration tool
-- Builds, tests, and deploys software continuously and monitors the execution and status of jobs
-- Trigger jobs manually, on a schedule, or on a code commit
-- Uses Java and Tomcat to do its work
+In this section, you will be learning how to deploy your golden image (and other artifacts) to a centralized location from your build pipeline.
 
 ## Artifactory
 
-  Artifactory is a versioned artifact repository. It is used to store multiple versions of different packages and supports different repository types (Maven, npm, Docker, etc). It is scalable and integrates with lots of other software delivery tools.
+  [Artifactory](https://jfrog.com/artifactory/install/) is a versioned artifact repository. It is used to store multiple versions of different packages and supports different repository types (Maven, npm, Docker, etc). It is scalable and integrates with lots of other software delivery tools.
+
+  ?> Artifactory is not free, but does have a 14 day [free trial](https://jfrog.com/start-free/) you can use. You will want to select the Self-Hosted option.
 
 ## Delivery Pipeline
 
@@ -48,28 +40,23 @@ In this section, you will be taking what you've learned about virtual machines t
 - Functional testing
 - Deploying artifacts
 
-# Exercise
+### Exercise
 
-Configure a Jenkins and Artifactory server and set up a Jenkins job to deploy a build artifact to Artifactory.
+Configure a GitHub Action to deploy a build artifact to Artifactory.
 
- 1. Create a clone of your Golden Image from the previous section and [install Jenkins](https://wiki.jenkins.io/display/JENKINS/Installing+Jenkins+on+Red+Hat+distributions).
- 2. In GitHub, fork the [spring-petclinic](https://github.com/spring-projects/spring-petclinic) project.
- 3. Create a Maven job in Jenkins to build your fork of spring-petclinic.
-
-   ?> You may need to install some dependencies for the project to build successfully.
- 4. Create another clone of your Golden Image and [install Artifactory OSS](https://www.jfrog.com/confluence/display/JFROG/Installing+Artifactory). Create a Maven repository during the Artifactory setup.
- 5. Install the Artifactory Jenkins plugin.
- 6. Add a Post-Build Action to deploy the build artifacts to your Artifactory server.
- 7. Build the spring-petclinic job and confirm the artifacts are deployed to Artifactory.
+  1. Create a clone of your Golden Image from the previous section
+  2. Install Artifactory into this clone
+      * Make sure to select Maven as the repository option during setup.
+  2. Use [Ngrok](https://ngrok.com/) to expose your Artifactory server.
+  3. In GitHub, fork the [spring-petclinic](https://github.com/spring-projects/spring-petclinic) project.
+  4. Open up the `maven-build` GitHub Action Workflow in the fork.
+  6. Add a `upload` task to your workflow that uploads the build output to your Artifactory server.
+  7. Commit your changes to the fork and verify that your workflow completed successfully.
+  8. Open the admin panel for your Artifactory server and verify that you see new artifacts have been uploaded.
 
 ### Extra Credit
 
-Working as a group, configure your Jenkins server to deploy to someone else's Artifactory server using what you have learned about virtual networks.
-
-?> If you are working on different networks you may need to use a tool like [Ngrok](https://ngrok.com/) to bridge communication between your servers over the internet.
-
-![devices image](img2/devices_light.svg ':size=100x100 :class=light-mode-icon :alt= devices image; light mode')
-![devices image](img2/devices_dark.svg ':size=100x100 :class=dark-mode-icon :alt= devices image; dark mode')
+Change your GitHub Action Workflow.  Remove your `upload` task instead add tasks to create a `GitHub Release` in your spring-petclinic fork and upload the build artifacts created to that release.
 
 # Deliverables
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,19 +85,17 @@ docs/2-virtual-machines-containers/2.3-managing-infrastructure.md:
   category: Virtualization
   estReadingMinutes: 10
   exercises:
-    - name: Jenkins and Artifactory on VMs
+    - name: Artifactory on VMs
       description: >-
-        Create VMs from your golden image. On one VM install Jenkins and
-        configure workflow to build Spring’s PetClinic. On the other VM install
-        and configure Artifactory. Configure these VMs so they can communicate
-        and create another workflow that pushes the build artifact from the
-        Jenkins server to Artifactory
+        Create a VM from your golden image and install and configure Artifactory
+        and deploy an artifact to that VM from a GitHub Action
       estMinutes: 390
       technologies:
         - Vagrant
         - CentOS
-        - Jenkins
+        - GitHub Actions
         - Artifactory
+        - Ngrok
 docs/2-virtual-machines-containers/2.4-containers.md:
   category: Containerization
   estReadingMinutes: 20


### PR DESCRIPTION
Removed Jenkins entirely and swapped for GitHub Actions

Also swapped out the extra credit exercise to be about doing a GitHub Release and uploading build artifacts there instead