### PR TITLE
Maven jenkins to GitHub

### DIFF
--- a/docs/5-release-management/5.3.2-maven-integration.md
+++ b/docs/5-release-management/5.3.2-maven-integration.md
@@ -17,11 +17,11 @@ docs/5-release-management/5.3.2-maven-integration.md:
 
 Let's bring this all together and think about the process of releasing software.
 
-Imagine PetClinic, Joda-Time, and Junit being maintained by 3 different teams working towards the same production release date.
+Imagine PetClinic, Joda-Time, and Junit being maintained by 2 different teams working towards the same production release date.
 
-One thing that is very important in software delivery is to know the exact version of all artifacts being released. Archive the versions with Maven.
+One thing that is very important in software delivery is to know the exact version of all artifacts being released.
 
-Everything that will be released (including dependencies) must be release versions, not SNAPSHOT's.
+Everything that will be released (including dependencies) must be release versions, not [SNAPSHOT](https://maven.apache.org/guides/getting-started/index.html#what-is-a-snapshot-version)'s.
 
 Here are two ways of doing this.
 
@@ -33,32 +33,38 @@ Here are two ways of doing this.
 - [Maven Release Plugin: The Final Nail in the Coffin](https://axelfontaine.com/blog/final-nail.html) by Axel Fontaine
 - [Building and testing Java with Maven (GitHub Actions)](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven)
 
-## Exercise - Maven Integration
+## Exercise - Maven Deploy to Artifactory
 
 This section is designed to give you an introduction into how Maven interacts with Artifactory and how to use Maven in GitHub Actions.
 
-1. Fork spring-petclinic, joda-time hibernate, and junit.
-2. Setup your local Artifactory for storing artifacts for all three repositories.  
-3. Using Maven CLI, build and deploy the snapshot artifacts to Artifactory.
-    - Double check the location you are deploying to (as defined by your Maven snapshot and release repository settings).
-4. Create GitHub Actions workflow to build and deploy artifacts to Artifactory on commits to the remote repository.
+1. Fork the following repos:
+   - [spring-petclinic](https://github.com/spring-projects/spring-petclinic)
+   - [joda-time](https://github.com/JodaOrg/joda-time)
+2. Update the `spring-petclinic`'s pom.xml to have a dependency defined for `joda-time` and build `spring-petclinic` to confirm it works
+   - You can find the latest version of `joda-time` from Maven Central repository [here](https://mvnrepository.com/artifact/joda-time/joda-time) (*if you click on the version, Maven will even generate the pom.xml code needed*)
+2. Setup your local Artifactory for storing artifacts for both repositories.  
+3. Using Maven CLI, build and deploy the both projects to Artifactory.
+    - Make sure to update the pom.xml to define the [distribution management](https://maven.apache.org/pom.html#repository) snapshot and release repository definitions to use your local Artifactory repository paths.
+    - Make sure to update your [settings.xml](https://maven.apache.org/settings.html#servers) with authentication for your Artifactory repositories.
+    - Take note of which Artifactory repository the artifact was deployed to.
+4. Change the version of joda-time to a release version.
+5. Validate the deployments to the Artifactory Releases repository worked.
+6. Attempt to deploy that same release version again.
+    - Take note of what happened in this attempt.
+7. Bump up the `joda-time` dependency version in the `spring-petclinic` pom.xml to a version that is higher than the latest (*we expect to fail the build doing this*)
+8. Bump up the release version of the `joda-time` repo so it matches the version `spring-petclinic` is now dependent on. Deploy this release to your local Artifactory
+9. Try building `spring-petclinic` again.
+   - Did this fix the build? Why not?
+   - Take note of why `spring-petclinic` cannot find that version of `joda-time`
+10. **`Challenge:`** Fix `spring-petclinic` so it pull the `joda-time` dependency at the bumped up from your local Artifactory repo.
+
+## Exercise - Maven in GitHub Actions
+
+1. Create GitHub Actions workflow to build and deploy artifacts to Artifactory on commits to the remote repository.
     - Make sure to expose local Artifactory with ngrok so GitHub runners can reach it
-5. Mess with things, and see what happens.
-    - Make some changes to code.
-    - Change some of the versions.
-6. Change one of the versions to a release version.
-7. Validate the deployments to the Artifactory Releases repository worked.
-8. Attempt to deploy that same release version again.
-9. Create GitHub Action jobs build dependent projects build when dependency artifacts are built and deployed successfully.
-
-## Exercise - Confirming Version in Artifactory
-
-1. Download the latest version of spring-petclinic from your Artifactory repository.
-2. Open up the WAR file.
-3. Find the joda-time hibernate library inside the WAR file.
-4. What version are you getting? Check with your lead to ensure this is the correct version.
-5. Clone joda-time-hibernate and verify the [buildnumber-maven-plugin](http://www.mojohaus.org/buildnumber-maven-plugin/usage.html) is included so two values are added to the Maven metadata file.
-    - SCM Revision Number and Build Timestamp
+    - A good starting point is GitHub's [Publish Java packages with Maven](https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven)
+    - You can also try to accomplish this with the GitHub Action [Java Maven release](https://github.com/marketplace/actions/java-maven-release)
+2. **`Challenge:`** [Create GitHub Action jobs](https://github.com/marketplace/actions/github-action-build-chain-cross-repo-builds) to build dependent projects build when dependency artifacts are built successfully. (*on successful artifact build of joda-time, the spring-petclinic should get built as well*)
 
 ![river image](img5/river_light.svg ':size=100x100 :class=light-mode-icon :alt= river image; light mode')
 ![river image](img5/river_dark.svg ':size=100x100 :class=dark-mode-icon :alt= river image; dark mode')
@@ -66,8 +72,6 @@ This section is designed to give you an introduction into how Maven interacts wi
 ## Tips
 
 - Make sure you are adding the necessary plugin defnitions to the pom.xml for the Maven goals you are trying to execute.
-- Make sure to be creating Maven jobs in GitHub Actions.
-- Is the GitHub Actions job using the correct `settings.xml`? Are you sure?
 - What does the ID in the Distribution Management section align with?
 - Have you created a release version twice?
 - Don't rush. Think about what is going on behind the scenes.

--- a/docs/5-release-management/5.3.2-maven-integration.md
+++ b/docs/5-release-management/5.3.2-maven-integration.md
@@ -31,6 +31,7 @@ Here are two ways of doing this.
 ## Reading
 
 - [Maven Release Plugin: The Final Nail in the Coffin](https://axelfontaine.com/blog/final-nail.html) by Axel Fontaine
+- [Building and testing Java with Maven (GitHub Actions)](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven)
 
 ## Exercise - Maven Integration
 
@@ -41,6 +42,7 @@ This section is designed to give you an introduction into how Maven interacts wi
 3. Using Maven CLI, build and deploy the snapshot artifacts to Artifactory.
     - Double check the location you are deploying to (as defined by your Maven snapshot and release repository settings).
 4. Create GitHub Actions workflow to build and deploy artifacts to Artifactory on commits to the remote repository.
+    - Make sure to expose local Artifactory with ngrok so GitHub runners can reach it
 5. Mess with things, and see what happens.
     - Make some changes to code.
     - Change some of the versions.
@@ -63,6 +65,7 @@ This section is designed to give you an introduction into how Maven interacts wi
 
 ## Tips
 
+- Make sure you are adding the necessary plugin defnitions to the pom.xml for the Maven goals you are trying to execute.
 - Make sure to be creating Maven jobs in GitHub Actions.
 - Is the GitHub Actions job using the correct `settings.xml`? Are you sure?
 - What does the ID in the Distribution Management section align with?

--- a/docs/5-release-management/5.3.2-maven-integration.md
+++ b/docs/5-release-management/5.3.2-maven-integration.md
@@ -5,11 +5,11 @@ docs/5-release-management/5.3.2-maven-integration.md:
   exercises:
     -
       name: Maven Integration
-      description: Get an introduction into how Maven interacts with Jenkins and Artifactory. Fork several projects, create Jenkins jobs that build these projects, deploy artifacts to Artifactory, set up jobs to build on commit, make changes and observe the results.
+      description: Get an introduction into how Maven interacts with Artifactory and how to use Maven in GitHub Actions. Fork several projects, use GitHub Actions to create GitHub workflow jobs that build these projects, deploy artifacts to Artifactory, set up jobs to build on commit, make changes and observe the results.
       estMinutes: 240
       technologies:
       - Maven
-      - Jenkins
+      - GitHub Actions
       - Artifactory
 ---
 
@@ -25,33 +25,29 @@ Everything that will be released (including dependencies) must be release versio
 
 Here are two ways of doing this.
 
-- Using the [Maven release plugin](http://maven.apache.org/maven-release/maven-release-plugin/).
-- Manually updating `pom.xml` files and using Jenkins automatically building every code push to release.
+- Using the [Maven release plugin](http://maven.apache.org/maven-release/maven-release-plugin/) with Maven CLI.
+- Using the [Third-Party Maven release GitHub Action](https://github.com/marketplace/actions/java-maven-release) to release artifacts as part of the GitHub workflow.
 
 ## Reading
 
 - [Maven Release Plugin: The Final Nail in the Coffin](https://axelfontaine.com/blog/final-nail.html) by Axel Fontaine
-- [A New Way to Do Continuous Delivery with Maven and Jenkins Pipeline](https://www.cloudbees.com/blog/new-way-do-continuous-delivery-maven-and-jenkins-pipeline) by cloudbees.com
 
 ## Exercise - Maven Integration
 
-This section is designed to give you an introduction into how Maven interacts with Jenkins and Artifactory. Jenkins offers a plugin for Maven that helps seamlessly add the integration between the two tools.
+This section is designed to give you an introduction into how Maven interacts with Artifactory and how to use Maven in GitHub Actions.
 
 1. Fork spring-petclinic, joda-time hibernate, and junit.
-2. Use your local Jenkins + Artifactory virtual machine and create jobs that build all three projects.
-3. Deploy the artifacts to Artifactory.
-    - Double check the location you are deploying to.
-    - It may be a good idea to do `clean install` before `clean deploy`.
-4. Set up all three jobs to build on commit with Git polls.
-    - First, configure Git polling to build the Jenkins jobs.
-    - Next, configure using a webhook and Ngrok.
+2. Setup your local Artifactory for storing artifacts for all three repositories.  
+3. Using Maven CLI, build and deploy the snapshot artifacts to Artifactory.
+    - Double check the location you are deploying to (as defined by your Maven snapshot and release repository settings).
+4. Create GitHub Actions workflow to build and deploy artifacts to Artifactory on commits to the remote repository.
 5. Mess with things, and see what happens.
     - Make some changes to code.
     - Change some of the versions.
 6. Change one of the versions to a release version.
 7. Validate the deployments to the Artifactory Releases repository worked.
 8. Attempt to deploy that same release version again.
-9. Configure Jenkins so that when dependency artifacts build successfully, the dependent projects build as well.
+9. Create GitHub Action jobs build dependent projects build when dependency artifacts are built and deployed successfully.
 
 ## Exercise - Confirming Version in Artifactory
 
@@ -67,8 +63,8 @@ This section is designed to give you an introduction into how Maven interacts wi
 
 ## Tips
 
-- Make sure to be creating Maven jobs in Jenkins.
-- Is Jenkins using the correct `settings.xml`? Are you sure?
+- Make sure to be creating Maven jobs in GitHub Actions.
+- Is the GitHub Actions job using the correct `settings.xml`? Are you sure?
 - What does the ID in the Distribution Management section align with?
 - Have you created a release version twice?
 - Don't rush. Think about what is going on behind the scenes.
@@ -77,6 +73,6 @@ This section is designed to give you an introduction into how Maven interacts wi
 
 Discuss what a release is and how they can be performed.
 
-Discuss how rebuilding release versions twice in Jenkins can cause downstream issues and the benefits of plugins such as buildnumber.
+Discuss the benefits of plugins such as buildnumber and the benefits of Artifactory Maven repo settings for version control of artifacts.
 
 Discuss with your group any difficulties you ran into, what worked well, and show off your completed deployment setup.

--- a/docs/README.md
+++ b/docs/README.md
@@ -503,7 +503,7 @@ docs/4-software-development-practices/4.5.6-sonarqube.md:
   category: Software Quality
   estReadingMinutes: 10
   exercises:
-    - name: Setup SonarQube and Jenkins Integration
+    - name: Setup SonarQube and GitHub Integration
       description: >-
         Create a SonarQube server and add GitHub action to run SonarQube in our
         build pipeline.
@@ -564,14 +564,15 @@ docs/5-release-management/5.3.2-maven-integration.md:
   exercises:
     - name: Maven Integration
       description: >-
-        Get an introduction into how Maven interacts with Jenkins and
-        Artifactory. Fork several projects, create Jenkins jobs that build these
-        projects, deploy artifacts to Artifactory, set up jobs to build on
-        commit, make changes and observe the results.
+        Get an introduction into how Maven interacts with Artifactory and how to
+        use Maven in GitHub Actions. Fork several projects, use GitHub Actions
+        to create GitHub workflow jobs that build these projects, deploy
+        artifacts to Artifactory, set up jobs to build on commit, make changes
+        and observe the results.
       estMinutes: 240
       technologies:
         - Maven
-        - Jenkins
+        - GitHub Actions
         - Artifactory
 docs/5-release-management/5.3.3-make.md:
   category: CI/CD


### PR DESCRIPTION
replace Maven Jenkins build/deploy instructions with GitHub Actions instructions