### PR TITLE
added new link to NPM introduction

### DIFF
--- a/docs/6-release-management/6.2.4-npm.md
+++ b/docs/6-release-management/6.2.4-npm.md
@@ -19,7 +19,7 @@ Npm is similar to Maven in that it provides a central document that determines t
 
 Read [About npm](https://www.npmjs.com/about), [What is npm?](https://docs.npmjs.com/getting-started/what-is-npm), and [Working with package.json](https://docs.npmjs.com/getting-started/using-a-package.json).
 
-Watch [this introductory video](https://www.youtube.com/watch?v=x03fjb2VlGY).
+Watch [this introductory video](https://www.youtube.com/watch?v=P3aKRdUyr0s).
 
 Go over the rest of the [npm documentation](https://docs.npmjs.com).
 


### PR DESCRIPTION
The existing video link is set to private. I found a new video (15 min) and goes over the basics of NPM, how to use it, what it's used for, and a bit about semantic versioning.

old link: https://www.youtube.com/watch?v=x03fjb2VlGY
new ling: https://www.youtube.com/watch?v=P3aKRdUyr0s