### PR TITLE
Correcting incorrect function hint

### DIFF
--- a/docs/4-cloud-computing/4.2.5-lambda.md
+++ b/docs/4-cloud-computing/4.2.5-lambda.md
@@ -126,7 +126,7 @@ instances = ec2.describe_instances(Filters=filter)
 
 1. Create an IAM role with the necessary permissions, including a custom policy to allow your Lambda function to start and stop EC2 instances
 2. We want to be able to stop our instance based on the time we last started it.
-   The field for this is "Launch Time".  The command that gives us access to this is `describe_instance_status()`. Pick a time and test the code to see if our instance is correctly stopped.
+   The field for this is "Launch Time".  The command that gives us access to this is `describe_instances()`. Pick a time and test the code to see if our instance is correctly stopped.
 3. Create a Dynamodb table either through the web interface or just in your lambda function.  However you do it, initialize a resource for it and grab your table.
 4. Store this data along with a few other things you feel we should know about this instance or instances inside our Dynamodb database.
 


### PR DESCRIPTION
Bootcamp references describe_instance_status() to find the launch-time field-- this field is not accessable through describe_instance_status() but is in describe_instances().