### PR TITLE
fixed syntax error (myPod -> my-pod)

### DIFF
--- a/docs/8-kubernetes-container-orchestration/8.2-volumes.md
+++ b/docs/8-kubernetes-container-orchestration/8.2-volumes.md
@@ -55,7 +55,7 @@ Here is a pod definition yaml that uses an alpine image, generates a random numb
 apiVersion: v1
 kind: Pod
 metadata:
-  name: myPod
+  name: my-pod
 spec:
   containers:
     - name: alpine

--- a/examples/ch8/volumes/random-num-pod.yaml
+++ b/examples/ch8/volumes/random-num-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: myPod
+  name: my-pod
 spec:
   containers:
     - name: alpine


### PR DESCRIPTION
Kubernetes requires lower case for the metadata name. I changed the example code in the examples folder and on the page that displays the contents of the file.

<img width="627" alt="image" src="https://github.com/liatrio/devops-bootcamp/assets/98495215/b9685aee-7cf4-4e90-b865-8ef8c5684bf0">
