### PR TITLE
Modified section 8.5 to use `v2` instead of `v2beta2`

### DIFF
--- a/docs/8-kubernetes-container-orchestration/8.5-hpas.md
+++ b/docs/8-kubernetes-container-orchestration/8.5-hpas.md
@@ -85,15 +85,15 @@ kubectl run -i --tty load-generator --rm --image=busybox --restart=Never -- /bin
 
 ## HPAs with Multiple Metrics
 
-HPAs can be configured with multiple metrics; this requires switching the apiVersion from "autoscaling/v1" to "autoscaling/v2beta2" among other changes. Update Docker Desktop if this API version doesn't show up when you run `kubectl api-versions | grep autoscaling`.
+HPAs can be configured with multiple metrics; this requires switching the apiVersion from "autoscaling/v1" to "autoscaling/v2" among other changes. Update Docker Desktop if this API version doesn't show up when you run `kubectl api-versions | grep autoscaling`.
 
 1. Add "memory" under resource *requests* and *limits* in the "php-apache" deployment with `kubectl edit deploy php-apache` for 10.5M and 42M respectively.
 
 2. Output your current HPA to a file by `kubectl get hpa php-apache -o yaml > hpa.yaml`.
 
-3. Edit the file to support v2beta2 and add an additional metric for memory with the average value set to 12M.
+3. Edit the file to support v2 and add an additional metric for memory with the average value set to 12M.
 
-4. Delete the old HPA and apply the v2beta2 version.
+4. Delete the old HPA and apply the v2 version.
 
 5. Memory should now be visible alongside CPU as targets when running the command `kubectl get hpa php-apache`.
 


### PR DESCRIPTION
`v2beta2` is deprecated and needed to be changed to `v2` instead.