### PR TITLE
Update az vmscalesets

### DIFF
--- a/docs/4-cloud-computing/4.3.3-vmss.md
+++ b/docs/4-cloud-computing/4.3.3-vmss.md
@@ -59,7 +59,7 @@ az storage file upload-batch -h
 
 9. Update the cloud-init script for VMSS. It now will mount Azure Files share containing our Node.js app and launch from that mount. This way multiple VMs can serve the same content from a central location.
 
-!> The below won't work unless you have properly setting environment variables for STORAGE_ACCOUNT, SHARE_NAME, and STORAGE_KEY.
+!> Substitue these values STORAGE_ACCOUNT, SHARE_NAME, and STORAGE_KEY.
 
 ```yaml
 #cloud-config
@@ -86,7 +86,7 @@ write_files:
       }
 runcmd:
   - mkdir "/mnt/webapp"
-  - 'mount -t cifs //$STORAGE_ACCOUNT.file.core.windows.net/$SHARE_NAME /mnt/webapp -o vers=3.0,username=$STORAGE_ACCOUNT,password=$STORAGE_KEY,dir_mode=0755,file_mode=0664'
+  - 'mount -t cifs //STORAGE_ACCOUNT.file.core.windows.net/SHARE_NAME /mnt/webapp -o vers=3.0,username=STORAGE_ACCOUNT,password=STORAGE_KEY,dir_mode=0755,file_mode=0664'
   - service nginx restart
   - cd "/mnt/webapp"
   - nodejs index.js

--- a/docs/4-cloud-computing/4.3.3-vmss.md
+++ b/docs/4-cloud-computing/4.3.3-vmss.md
@@ -106,7 +106,7 @@ runcmd:
 
 12. Get the public IP for load balancer and make sure we can reach the Node.js app using cURL. You should see responses from both instances in the scale set.
 
-13. Create an autoscaling profile with a resource type of Microsoft.Compute/virtualMachineScaleSets. The minimum number of VMs should be 2 and the maximum should be 4. Make sure to set the default amount. 
+13. Create an autoscaling profile with a resource type of Microsoft.Compute/virtualMachineScaleSets. The minimum number of VMs should be 2 and the maximum should be 4. Make sure to set the default amount.
 
 ```bash
 # This will come in handy later.
@@ -131,3 +131,10 @@ sudo apt-get -y install stress ; sudo stress --cpu 10 --timeout 420 &
 18. Confirm if a new instance has been added after about 5 minutes. After waiting for the stress test to finish and another 5 minutes, the scale set should return to 2 instances.
 
 19. Cleanup by deleting the resource group.
+
+## Deliverables
+
+- Are there other ways to authenticate with a virtual machine instance other than using already generated ssh keys?
+- What are the specific Azure CLI query commands that can be used to assign the public IP into a variable?
+- What is cloud-init, and why is it an industry standard?
+- How can the process be automated or streamlined for efficient deployment and management?

--- a/docs/4-cloud-computing/4.3.3-vmss.md
+++ b/docs/4-cloud-computing/4.3.3-vmss.md
@@ -33,7 +33,7 @@ In this section we will demonstrate how Virtual Machine Scale Sets (VMSS) work i
 
 5. Use Azure CLI to create a file share in the storage account with a 1GB quota. Populate the environment variable SHARE_NAME with the name of your new file share.
 
-6. Create a simple Node.js app that returns the hostname of the VM (same one we used in section 4.3.2). 
+6. Create a simple Node.js app that returns the hostname of the VM (same one we used in section 4.3.2).
 
 ?> Make sure you are starting in an empty directory.
 

--- a/docs/4-cloud-computing/4.3.3-vmss.md
+++ b/docs/4-cloud-computing/4.3.3-vmss.md
@@ -6,7 +6,7 @@ docs/4-cloud-computing/4.3.3-vmss.md:
     -
       name: Create VMSS and serve content from Azure Storage Account
       description: Create a VMSS and serve content from an Azure Storage Account. Do this via the cli, deploying a simple node web app and provision the VM's with cloud-init.
-      estMinutes: 240
+      estMinutes: 330
       technologies:
       - Azure
       - Azure VMSS
@@ -59,6 +59,8 @@ az storage file upload-batch -h
 
 9. Update the cloud-init script for VMSS. It now will mount Azure Files share containing our Node.js app and launch from that mount. This way multiple VMs can serve the same content from a central location.
 
+!> The below won't work unless you have properly setting environment variables for STORAGE_ACCOUNT, SHARE_NAME, and STORAGE_KEY.
+
 ```yaml
 #cloud-config
 package_update: true
@@ -89,8 +91,6 @@ runcmd:
   - cd "/mnt/webapp"
   - nodejs index.js
 ```
-
-!> The above won't work unless you have properly setting environment variables for STORAGE_ACCOUNT, SHARE_NAME, and STORAGE_KEY.
 
 10. Create a VMSS with Azure CLI that uses our updated cloud-init script. Use the same SSH keys you generated in section 4.3.2. Specify an instance count of 2 for the scale set. Use environment variable VMSS_NAME to hold the value for the name of the scale set.
 
@@ -134,7 +134,6 @@ sudo apt-get -y install stress ; sudo stress --cpu 10 --timeout 420 &
 
 ## Deliverables
 
-- Are there other ways to authenticate with a virtual machine instance other than using already generated ssh keys?
-- What are the specific Azure CLI query commands that can be used to assign the public IP into a variable?
-- What is cloud-init, and why is it an industry standard?
-- How can the process be automated or streamlined for efficient deployment and management?
+- What is the purpose of Azure Virtual Machine Scale Sets (VMSS)?
+- Explain the difference between scaling out and scaling in within the context of VMSS.
+- Discuss how VMSS would be used in a real-world scenario, such as a large-scale web service.

--- a/docs/4-cloud-computing/4.3.3-vmss.md
+++ b/docs/4-cloud-computing/4.3.3-vmss.md
@@ -33,11 +33,11 @@ In this section we will demonstrate how Virtual Machine Scale Sets (VMSS) work i
 
 5. Use Azure CLI to create a file share in the storage account with a 1GB quota. Populate the environment variable SHARE_NAME with the name of your new file share.
 
-6. Create a simple Node.js app that returns the hostname of the VM (same one we used in section 4.3.2).
+6. Create a simple Node.js app that returns the hostname of the VM (same one we used in section 4.3.2). 
 
-```bash
-mkdir /Users/YOUR_NAME/webapp
-cat <<EOF > /Users/YOUR_NAME/webapp/index.js
+?> Make sure you are starting in an empty directory.
+
+```js
 var express = require('express')
 var app = express()
 var os = require('os');
@@ -47,30 +47,19 @@ app.get('/', function (req, res) {
 app.listen(3000, function () {
   console.log('Test app listening on port 3000!')
 })
-EOF
 ```
 
 7. Build the Node.js app locally first. Launch it locally and make sure it works.
 
-```bash
-cd /Users/YOUR_NAME/webapp
-npm init --yes
-npm install express -y
-```
-
 8. Upload the Node.js app to Azure file share we created in step 5.
 
 ```bash
-az storage file upload-batch \
-  --account-key $STORAGE_KEY \
-  --account-name $STORAGE_ACCOUNT \
-  --destination $SHARE_NAME --source /Users/YOUR_NAME/webapp
+az storage file upload-batch -h
 ```
 
 9. Update the cloud-init script for VMSS. It now will mount Azure Files share containing our Node.js app and launch from that mount. This way multiple VMs can serve the same content from a central location.
 
-```bash
-cat <<EOF > /Users/YOUR_NAME/cloud-init-vmss.txt
+```yaml
 #cloud-config
 package_update: true
 package_upgrade: true
@@ -99,43 +88,30 @@ runcmd:
   - service nginx restart
   - cd "/mnt/webapp"
   - nodejs index.js
-EOF
 ```
 
-?> The above won't work unless you have properly setting environment variables for STORAGE_ACCOUNT, SHARE_NAME, and STORAGE_KEY.
+!> The above won't work unless you have properly setting environment variables for STORAGE_ACCOUNT, SHARE_NAME, and STORAGE_KEY.
 
 10. Create a VMSS with Azure CLI that uses our updated cloud-init script. Use the same SSH keys you generated in section 4.3.2. Specify an instance count of 2 for the scale set. Use environment variable VMSS_NAME to hold the value for the name of the scale set.
 
 ?> It can take several minutes to provision the VMSS. For bonus points, deploy the VMSS with different VM SKU sizes and note the differences in deployment times.
 
-11. When the VMSS was created, it automatically created a load balancer instance. Let's add a load balancing rule to it so we can reach our Node.js app.
+11. When the VMSS was created, it automatically created a load balancer instance. Add a **load balancing network rule** to it so we can reach our Node.js app. The load balancer name will be your VMSS_NAME with and LB at the end. Similarly.
 
-```bash
-az network lb rule create \
-  --resource-group $RESOURCE_GROUP \
-  --name myLoadBalancerRuleWeb \
-  --lb-name "${VMSS_NAME}LB" \
-  --backend-pool-name "${VMSS_NAME}LBBEPool" \
-  --backend-port 80 \
-  --frontend-ip-name loadBalancerFrontEnd \
-  --frontend-port 80 \
-  --protocol tcp
-```
+- The name of the load balancer that was created is "${VMSS_NAME}LB"
+- Backend pool name should be "${VMSS_NAME}LBBEpool"
+- Use tcp protocol
+- Use port 80
+- There are more required arguments (explore around)
 
 12. Get the public IP for load balancer and make sure we can reach the Node.js app using cURL. You should see responses from both instances in the scale set.
 
-13. Create an autoscaling profile.
+13. Create an autoscaling profile with a resource type of Microsoft.Compute/virtualMachineScaleSets. The minimum number of VMs should be 2 and the maximum should be 4. Make sure to set the default amount. 
 
 ```bash
+# This will come in handy later.
 AUTOSCALE_PROFILE=YOUR_NAMEautoscaleprofile123
-az monitor autoscale create \
-  --resource-group $RESOURCE_GROUP \
-  --resource $VMSS_NAME \
-  --resource-type Microsoft.Compute/virtualMachineScaleSets \
-  --name $AUTOSCALE_PROFILE \
-  --min-count 2 \
-  --max-count 4 \
-  --count 2
+az monitor autoscale create -h
 ```
 
 14. Use Azure CLI to create some scale-in and scale-out rules based on CPU usage for the autoscaler profile you just created. Your scale-out rule should trigger when CPU percentage is over 70% over a 5 min period. Your scale-in rule should trigger when CPU percentage has dropped below 30% over a 5 min period.
@@ -143,12 +119,6 @@ az monitor autoscale create \
 15. Use Azure CLI to check how many instances are currently running in the scale set.
 
 16. Get the connection info for the individual instances in the scale set.
-
-```bash
-az vmss list-instance-connection-info \
-  --resource-group $RESOURCE_GROUP \
-  --name $VMSS_NAME
-```
 
 17. SSH into each instance and generate some load so we can trigger the scale-out rule. Use the top command to ensure CPU usage is increasing before you log out of the instance.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -404,7 +404,7 @@ docs/4-cloud-computing/4.3.3-vmss.md:
         Create a VMSS and serve content from an Azure Storage Account. Do this
         via the cli, deploying a simple node web app and provision the VM's with
         cloud-init.
-      estMinutes: 240
+      estMinutes: 330
       technologies:
         - Azure
         - Azure VMSS


### PR DESCRIPTION
Updating this section to be in line with the AWS section. 

- Removed most of the handholding code.
- Added deliverables

Deliverables:
- What is the purpose of Azure Virtual Machine Scale Sets (VMSS)?
Purpose: Is to show how similar it is to AWS's Auto Scaling Groups. 
Answer: VMSS is used to configure, manage, and update identical virtual machines. 
- Explain the difference between scaling out and scaling in within the context of VMSS.
Purpose: Early introduction to horizontal scaling. Good to have this in your mind when you get to the Kubernetes section.
Answer: Scaling out (horizontal scaling) is where you add more virtual machines. Scaling in is where you reduce the number of virtual machines in your scale set.
- Discuss how VMSS would be used in a real-world scenario, such as a large-scale web service.
Purpose: To get the apprentices to think about the bigger picture. We learn a lot in the boot camp but much of it is bite sized for the sake of learning. 
Answer: Traffic control, load balancing, group management.