### PR TITLE
Rephrased Helm exercise 3

### DIFF
--- a/docs/6-release-management/6.3.2-helm.md
+++ b/docs/6-release-management/6.3.2-helm.md
@@ -99,9 +99,7 @@ In this exercise we will take an existing Helm chart which deploys the [DevOps K
 
 In this exercise we will add a Kubernetes deployment and service to our Helm chart to deploy the DKS frontend application.
 
-1. Change/Add the KNOWLEDGE_SHARE_API constant located in the `Dockerfile` file for the frontend project to reference `localhost`.
-
-?> In real networked environment it wouldn't make any sense to configure the application this way but it is necessary to demonstrate the application frontend communicating with the backend on our local environment.
+1. Change/Add the KNOWLEDGE_SHARE_API environment variable located in the `Dockerfile` file for the frontend project to reference the backend.
 
 2. Rebuild the Docker image and then push the new image to Dockerhub.
 
@@ -114,6 +112,10 @@ In this exercise we will add a Kubernetes deployment and service to our Helm cha
 ?> The notes output when you ran `helm install` should have some useful hints :)
 
 6. Open the frontend application in a web browser and verify it is communicating with the backend service.
+
+`Challenge:` Can you get the same outcome while ONLY port-forwarding the front-end?
+
+?> Hint: You might have already achieved this depending on how your frontend is communicating with your backend.
 
 ## Exercise 4
 

--- a/docs/6-release-management/6.3.2-helm.md
+++ b/docs/6-release-management/6.3.2-helm.md
@@ -115,7 +115,7 @@ In this exercise we will add a Kubernetes deployment and service to our Helm cha
 
 `Challenge:` Can you get the same outcome while ONLY port-forwarding the front-end?
 
-?> Hint: You might have already achieved this depending on how your frontend is communicating with your backend.
+?> Reading about [Kubernetes service discovery](https://kubernetes.io/docs/concepts/services-networking/service/#discovering-services) should give you some good direction on how to accomplish this. Think about how this idea ties in with how you've made the UI and API communicate up to this point.
 
 ## Exercise 4
 

--- a/examples/ch6/helm/DKS/templates/NOTES.txt
+++ b/examples/ch6/helm/DKS/templates/NOTES.txt
@@ -1,8 +1,8 @@
 DevOps Bootcamp: Anything in this notes file will be displayed when installing this Helm chart
 
 1. Once you have all three pods running successfully you will need to run the following commands:
-kubectl port-forward svc/frontend 4100:4100
-kubectl port-forward svc/backend 3000:3000
+kubectl port-forward svc/frontend 3000:3000
+kubectl port-forward svc/backend 8080:8080
 
 You can access your website by navigating to:
-http://localhost:4100
+http://localhost:3000


### PR DESCRIPTION
Updated the exercise 3 in Helm section to challenge apprentices to properly reference the backend service from the frontend. Added a challenge and hint to the exercise that suggests they can accomplish the exercise by only port-forwarding a single service. Small change to the Notes.txt in the Helm Example to display the correct ports. 