### PR TITLE
Added quiz about GitHub APIs #394

### DIFF
--- a/docs/2-Github/2.4-APIs.md
+++ b/docs/2-Github/2.4-APIs.md
@@ -43,7 +43,7 @@ docs/2-Github/2.4-APIs.md:
 
 #### With the GraphQL API
 
-I found the documentation on how to do graphql queries with octokit to be confusing and different sources have different ways of doing it so here is an example of a good way to go about it. If you are using Github's GraphQL explorer, you can pretty much just replace whats inside the backticks following the `query:` parameter with your own query or mutation.  The explorer also will usually give the query a name when creating new ones there which doesn't influence the query should you include it or not, as you can see the example does not.
+The documentation on how to do GraphQL queries with octokit can easily be confusing and different sources have different ways of doing it, so here is an example of a good way to go about it. If you are using Github's GraphQL explorer, you can pretty much just replace whats inside the backticks following the `query:` parameter with your own query or mutation. The explorer also will usually give the query a name when creating new ones there which doesn't influence the query should you include it or not, as you can see the example does not.
 
 ```javascript
 //This function gets the name and id of an organization as well as the id and title of one of the projects it owns.
@@ -71,6 +71,12 @@ async function getOrgAndProject(owner, projectNumber, token){
  2. In addition to that, create a new projectV2 and link it to the repo
 
  >Notice there are still problems you'll need to use multiple queries for, like ones that return information you need for other requests, however the total amount of requests you make shrinks drastically as well as the amount of information returned.  On top of that there are things only the GraphQL api can do like create and manage projectsV2
+
+## Knowledge Check
+
+<div class="quizdown">
+  <div id="chapter-2/2.4/api-quiz.js"></div>
+</div>
 
 ## Deliverables
 

--- a/src/quizzes/chapter-2/2.4/api-quiz.js
+++ b/src/quizzes/chapter-2/2.4/api-quiz.js
@@ -1,6 +1,6 @@
 const rawQuizdown = `
 
-# Assume you want to scrape a GitHub org for an entire list of its users and rich details about each of its repositories. Keeping rate limiting and efficiency in mind, which GitHub API would be preferable?
+# Assume you want to scrape a GitHub org for an entire list of its users and rich details about each of their repositories. Keeping rate limiting and efficiency in mind, which GitHub API would be preferable?
 
 1. [x] REST
 	> Good. You could achieve this in just one or two API calls

--- a/src/quizzes/chapter-2/2.4/api-quiz.js
+++ b/src/quizzes/chapter-2/2.4/api-quiz.js
@@ -1,0 +1,30 @@
+const rawQuizdown = `
+
+# Assume you want to scrape a GitHub org for an entire list of its users and rich details about each of its repositories. Keeping rate limiting and efficiency in mind, which GitHub API would be preferable?
+
+1. [x] REST
+	> Good. You could achieve this in just one or two API calls
+1. [ ] GraphQL
+	> In order to find all this info, you'd need to make many more API calls than with REST
+1. [ ] It doesn't make a difference
+	> While both APIs could query for all this information, they do so in different amounts of API calls
+
+# Assume you want to scrape a GitHub org for a specific repository's contributors list. Keeping rate limiting and efficiency in mind, which GitHub API would be preferable?
+
+1. [ ] REST
+	> REST does query for this pretty easily due to it having dedicated endpoints for certain things, but it's important to understand how GraphQL handles it, as well
+1. [ ] GraphQL
+	> GraphQL does do this very simply, but there is something else to keep in mind. While much of the time GraphQL *is* optimal for finer tuned examples, REST has something put in place for certain specific queries
+1. [x] It doesn't make a difference
+	> While you might think that GraphQL is optimal for this because REST typically returns more data than necessary, it's important to keep in mind REST's API endpoints. For example, REST has a **GET /repos/{owner}/{repo}/contributors** dedicated endpoint to retrieve exactly what is needed here. Because GraphQL can also perform this rather simply, it doesn't make much of a difference for this example
+
+# Which of the following statements are true? Select all that apply
+
+- [x] REST uses a uniform interface and a set of predefined endpoints to interact with resources
+- [ ] REST allows clients to specify the exact structure of the response and fetch only the required data
+- [ ] GraphQL uses a uniform interface and a set of predefined endpoints to interact with resources
+- [x] GraphQL allows clients to specify the exact structure of the response and fetch only the required data
+
+`;
+
+export { rawQuizdown }


### PR DESCRIPTION
- Added a quiz to section 2.4 that tests the understanding of some of the differences between REST and GraphQL
- Threw one "gotcha" in there in the form of question 2. The answer seems like it would be GraphQL because it can query for exactly what it wants, but REST actually has a dedicated endpoint for exactly what the prompt is talking about.

- Changed a sentence in the section as it broke the 4th wall and didn't read like the rest of the bootcamp
#394 
