### PR TITLE
Added quiz about GitHub security settings

### DIFF
--- a/docs/2-Github/2.5-Security.md
+++ b/docs/2-Github/2.5-Security.md
@@ -23,11 +23,13 @@ docs/2-Github/2.5-Security.md:
 
 # Github Security
 
+Some of GitHub's great, easy-to-use features are its multiple security measures. In this section, we'll walk through them and get you some practice on using them. Whenever you're working on a development project, security should be one of your top priorities, so these methods you're about to learn can serve as a great starting point.
+
 ## Code scanning
 
-Code scanning is a GitHub feature that allows you to automatically scan your code for security vulnerabilities. Code scanning works by integrating with third-party static analysis tools as well as Githubs CodeQL, which analyze your code for potential security issues such as buffer overflows, cross-site scripting (XSS) vulnerabilities, and SQL injection vulnerabilities. Code scanning can be set up to run automatically as part of your continuous integration (CI) pipeline, which helps catch vulnerabilities early in the development process.  The files these scans produce is in "SARIF" (Static Analysis Results Interchange Format) which is a industry standard format for security scanning tools which is also what the Security tab in Github expects when you upload results to it.
+Code scanning is a GitHub feature that allows you to automatically scan your code for security vulnerabilities. Code scanning works by integrating with third-party static analysis tools as well as Github's CodeQL, which analyze your code for potential security issues such as buffer overflows, cross-site scripting (XSS) vulnerabilities, and SQL injection vulnerabilities. Code scanning can be set up to run automatically as part of your continuous integration (CI) pipeline, which helps catch vulnerabilities early in the development process.  The files these scans produce is in "SARIF" (Static Analysis Results Interchange Format) which is an industry standard format for security scanning tools which is also what the Security tab in Github expects when you upload results to it.
 
-- Github developed its own code-scanning software called CodeQL which they have their own actions for so you can set it up pretty quickly with out of the box functionality for some interpreted languages like Python, Javascript, and Ruby and it automatically detects supported languages and puts those into the workflow for you.  For those languages that need to be compiled, you can still run the tool against them but you need to have a custom build step in your workflow before you analyse it. The short story of what it does is make a relational database out of your code and runs queries against it to detect a variety of potential issues then uploads the its findings to your security tab. (link to CodeQL docs [here](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-with-codeql))
+- Github developed its own code-scanning software called CodeQL which they have their own actions for so you can set it up pretty quickly with out of the box functionality for some interpreted languages like Python, Javascript, and Ruby and it automatically detects supported languages and puts those into the workflow for you. For those languages that need to be compiled, you can still run the tool against them but you need to have a custom build step in your workflow before you analyze it. The short story of what it does is make a relational database out of your code and runs queries against it to detect a variety of potential issues, then uploads its findings to your security tab. (link to CodeQL docs [here](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-with-codeql))
 
 ## Secret scanning
 
@@ -45,7 +47,7 @@ Dependabot security updates are automatic pull requests that update your depende
 
 ## Exercise 1
 
- For this first one, we will explore a bit more of the code-scanning side of Github security using CodeQL.  As mentioned previously, CodeQL has some good default workflows you can setup to help you get started with code-scanning.  You can either use that or a tool we refactored into Go based off of [mario-campos/gh-code-scanning](https://github.com/mario-campos/gh-code-scanning) which does basically the same thing except its cooler and it lives [here](https://github.com/liatrio/csgo) (still a work in progress).
+To start off, we will explore a bit more of the code-scanning side of Github security using CodeQL. As mentioned previously, CodeQL has some good default workflows you can setup to help you get started with code-scanning.  You can either use that or a tool we refactored into Go based off of [mario-campos/gh-code-scanning](https://github.com/mario-campos/gh-code-scanning) which does basically the same thing except its cooler and it lives [here](https://github.com/liatrio/csgo) (still a work in progress).
 
 1. Create a repository that includes some code from one of the many CodeQl supported interpreted languages like Python or Javascript. A [RealWorld](https://github.com/khaledosman/react-redux-realworld-example-app) project is a good place to start since they are typically old and not maintained.
 2. Using the tool of your choice or just go through the basic workflow configuration, enable code-scanning on your repository as well as create a basic workflow to start doing some code scanning with.
@@ -53,13 +55,13 @@ Dependabot security updates are automatic pull requests that update your depende
 
 ## Exercise 2
 
-This next part is pretty simple, however it shows you the power of Dependabot version and security updates.  These two features once enabled will give you insight into your outdated and risk-ridden dependencies with information inside the Security tab of your repository or from the PR's it automatically generates to update them.
+This next part is pretty simple, however it shows you the power of Dependabot version and security updates. Once enabled, these two features will give you insight into your outdated and risk-ridden dependencies with information inside the Security tab of your repository or from the PR's it automatically generates to update them.
 
 1. First we are going to need a bad project for Dependabot to scan which can either be the one from the previous exercise or another of your choice.  Once that is setup inside your repo, navigate to the `code security and analysis` tab in the settings of the repository to enable all three Dependabot features i.e. Alerts, Security Updates, and Version Updates.
 2. In the `dependabot.yml` file that is generated once you have enabled Version Updates, update the `package-ecosystem` option with whatever matches with the code in your repository.
 3. Now you just have to watch Dependabot automatically generate PR's and security notices to help you make your life easier when it comes to managing dependencies and security risks.  
 
-# Exercise 3
+## Exercise 3
 
 The last part of our adventure into Github's security features is secret-scanning.  This is a pretty important one as preventing secrets from entering your code base will save you the trouble of having to rotate keys and revoke credentials as well as potentially saving you money should that secret be able to grant access to critical infrastructure.
 
@@ -68,6 +70,12 @@ The last part of our adventure into Github's security features is secret-scannin
 3. Now we are going to create a secret, a github PAT is probably easiest and `MAKE SURE to not give it any permissions`. Although the push protection will stop it from being committed and we will delete it afterwards anyways, getting in the habit of keeping things as secure as possible is a very important one to build.  So go ahead and try to commit it and if all goes according to plan, Github should prevent you from doing so and send you an alert for it.  `Once again remember to get rid of it afterwards!`
 
 > Like was mentioned before, security is a habit that should be maintained.  Tools like these are meant to help prevent security risks should they come up but that does not mean you as a developer are relieved of that responsibility.  Tools like these are helpful but they are not infallable so always be aware of what you are doing and how you can do it in the safest way possible.
+
+## Knowledge Check
+
+<div class="quizdown">
+  <div id="chapter-2/2.5/security-quiz.js"></div>
+</div>
 
 ## Deliverables
 

--- a/docs/2-Github/2.5-Security.md
+++ b/docs/2-Github/2.5-Security.md
@@ -23,7 +23,7 @@ docs/2-Github/2.5-Security.md:
 
 # Github Security
 
-Some of GitHub's great, easy-to-use features are its multiple security measures. In this section, we'll walk through them and get you some practice on using them. Whenever you're working on a development project, security should be one of your top priorities, so these methods you're about to learn can serve as a great starting point.
+GitHub offers a range of excellent and user-friendly security features. In this section, we'll delve into these features, providing practical guidance on how to use them effectively. Given the critical importance of security in any development project, the methods we'll explore here will not only be highly beneficial for your current work but also serve as a solid foundation for your future projects.
 
 ## Code scanning
 

--- a/src/quizzes/chapter-2/2.5/security-quiz.js
+++ b/src/quizzes/chapter-2/2.5/security-quiz.js
@@ -22,7 +22,7 @@ shuffleQuestions: true
 1. [ ] Dependabot
 1. [ ] Code scanning
 1. [x] Secret Scanning
-	> You'll thank yourself later if you turn this on :)
+	> Most of us, at one point or another, have accidentally pushed a token to a GitHub repo. It's a simple mistake, but can easily get you into a serious mess. You'll thank yourself later if you turn this on
 `;
 
 export { rawQuizdown }

--- a/src/quizzes/chapter-2/2.5/security-quiz.js
+++ b/src/quizzes/chapter-2/2.5/security-quiz.js
@@ -17,7 +17,7 @@ shuffleQuestions: true
 	> Good. Code Scanning can be added to your pipeline to track down security risks such as SQL injection vulnerabilities. So long, Johnny Drop Tables :)
 1. [ ] Secret Scanning
 
-# Most of us, at one point or another, have accidentally pushed a token to a GitHub repo. It's a simple mistake, but can easily get you into a serious mess. Which tool can you use as the ultimate lifeline to help prevent this?
+# Which tool would stop you from committing a token to a GitHub repo?
 
 1. [ ] Dependabot
 1. [ ] Code scanning

--- a/src/quizzes/chapter-2/2.5/security-quiz.js
+++ b/src/quizzes/chapter-2/2.5/security-quiz.js
@@ -4,7 +4,7 @@ const rawQuizdown= `
 shuffleQuestions: true
 ---
 
-# In case you're worried about security risks stemming from dependency versioning, which of the security tools mentioned above would you use if you wanted to ensure your dependencies get safely updated?
+# Which tool is most effective for automatically upgrading libraries to reduce security vulnerabilities?
 
 1. [x] Dependabot
 1. [ ] Code scanning

--- a/src/quizzes/chapter-2/2.5/security-quiz.js
+++ b/src/quizzes/chapter-2/2.5/security-quiz.js
@@ -1,0 +1,28 @@
+const rawQuizdown= `
+
+---
+shuffleQuestions: true
+---
+
+# In case you're worried about security risks stemming from dependency versioning, which of the security tools mentioned above would you use if you wanted to ensure your dependencies get safely updated?
+
+1. [x] Dependabot
+1. [ ] Code scanning
+1. [ ] Secret Scanning
+
+# SOS!!! Your SQL database just got dropped by maliscious data injection! Which of the tools mentioned above can you apply to help prevent this in the future?
+
+1. [ ] Dependabot
+1. [x] Code scanning
+	> Good. Code Scanning can be added to your pipeline to track down security risks such as SQL injection vulnerabilities. So long, Johnny Drop Tables :)
+1. [ ] Secret Scanning
+
+# Most of us, at one point or another, have accidentally pushed a token to a GitHub repo. It's a simple mistake, but can easily get you into a serious mess. Which tool can you use as the ultimate lifeline to help prevent this?
+
+1. [ ] Dependabot
+1. [ ] Code scanning
+1. [x] Secret Scanning
+	> You'll thank yourself later if you turn this on :)
+`;
+
+export { rawQuizdown }


### PR DESCRIPTION
#394  
- Added a simple quiz that tests the differences between dependabot, code scanning, and secret scanning
- Added some text to the beginning of the section to act as an introduction

The quiz is only 3 questions, one for each setting. The section has users create a least-permission PAT and attempt to push it to GitHub to test out the secret scanning setting. Any thoughts on if I should add a question pertaining to that? It could add some value to the quiz, but isn't really the focus of the section.