### PR TITLE
1.3.4 - fixed brew --cask && 1.3.5 fixed quiz formatting

### DIFF
--- a/docs/1-introduction/1.3.4-passwords-and-keys.md
+++ b/docs/1-introduction/1.3.4-passwords-and-keys.md
@@ -38,7 +38,7 @@ KeePass lets you manage your passwords in a local encrypted database so you only
 
 <https://keepass.info/>
 
-`brew cask install keepassxc`
+`brew install keepassxc --cask`
 
 ### Lastpass
 

--- a/docs/1-introduction/1.3.5-networking.md
+++ b/docs/1-introduction/1.3.5-networking.md
@@ -89,12 +89,6 @@ portion of the address.
 | 192.168.5.40/24 | 255.255.255.0 | 192.168.5.0     |
 | 10.0.162.5/20   | 255.255.240.0 | 10.0.160.0      |
 
-## Knowledge Check
-
-<div class="quizdown">
-  <div id="chapter-1/1.3.5/subnets-quiz.js" ></div>
-</div>
-
 ## Private IP Ranges
 
 Finally, there are a few IP ranges that are reserved as private addresses.
@@ -107,6 +101,12 @@ within a private range will ensure no conflicts with public servers.
 | 10.0.0.0/8     | 10.0.0.0 - 10.255.255.255     | 16,777,216          |
 | 172.16.0.0/12  | 172.16.0.0 - 172.31.255.255   | 1,048,576           |
 | 192.168.0.0/16 | 192.168.0.0 - 192.168.255.255 | 65,536              |
+
+## Knowledge Check
+
+<div class="quizdown">
+  <div id="chapter-1/1.3.5/subnets-quiz.js" ></div>
+</div>
 
 ## Exercise
 


### PR DESCRIPTION
Fixed the brew cask install command to brew install <> --cask to work on Mac OS. Also fixed the formatting in 1.3.5 where the knowledge check occurred before the final teaching.