### PR TITLE
Update tag for packer-plugin-vmware repo to latest

### DIFF
--- a/docs/3-virtual-machines-containers/3.1-golden-images.md
+++ b/docs/3-virtual-machines-containers/3.1-golden-images.md
@@ -104,7 +104,7 @@ In this exercise, you will use Packer to create a Golden Image with the same con
 
 1. [Install Packer](https://learn.hashicorp.com/packer/getting-started/install) on your machine.
 
-2. Fork the [packer-plugin-vmware repo](https://github.com/hashicorp/packer-plugin-vmware/tree/v1.0.8), and checkout tag `v1.0.8`
+2. Fork the [packer-plugin-vmware repo](https://github.com/hashicorp/packer-plugin-vmware/tree/v1.0.11), and checkout tag `v1.0.11`
 
 3. Read [Provisioning in Packer](https://developer.hashicorp.com/packer/tutorials/docker-get-started/docker-get-started-provision) then modify `examples/build.pkr.hcl` such that your build artifact will be the same as the VM you configured in Exercise 1.
     - Update packages


### PR DESCRIPTION
Previous version of repo (1.0.8) requested missing resources during build.  Switching to v1.0.11 fixes this.  