### PR TITLE
Update base box OS to match template created in section 3.1

### DIFF
--- a/docs/3-virtual-machines-containers/3.2-local-development.md
+++ b/docs/3-virtual-machines-containers/3.2-local-development.md
@@ -34,18 +34,18 @@ You may have noticed some similarities between Packer and Vagrant. They both mak
 
 ## Exercise
 
-In this exercise we will create a Vagrant Base Box using our Packer template, upload our base box to VagrantCloud and then write a Vagrant file that starts your base box.
+In this exercise we will create a Vagrant Base Box using the Packer template we created in the previous section, upload our base box to VagrantCloud and then write a Vagrant file that starts your base box.
 
 Read [Creating a Base Box](https://www.vagrantup.com/docs/boxes/base) and [Creating a (VMWare) Base Box](https://developer.hashicorp.com/vagrant/docs/providers/vmware/boxes).
 
 1. Modify your Packer build file to meet Vagrant's Base Box requirements.
     - allow the `vagrant` user to have password-less sudo
     - `UseDNS no` (optional)
-    - update the CentOS packages and kernel
+    - update the Debian packages and kernel
     - install Vagrant [insecure key pair](https://github.com/hashicorp/vagrant/tree/master/keys) for `vagrant` user
     - install Guest Additions
 
-    ?> Many of Vagrant requirements are already taken care of for you in the example. It is up to you to figure out which one(s) you need to add
+    ?> Many of Vagrant requirements are already taken care of for you in the example. It is up to you to figure out which one(s) you need to add.
 
 2. Add a [Vagrant `post-processor`](https://www.packer.io/docs/post-processors/vagrant/vagrant) to your Packer build template. Configure it to output both a VMWare Fusion image and a Vagrant box.
 


### PR DESCRIPTION
The template from 3.1 uses a Debian iso in its Packer config files.  Updated instructions from this section's exercise to have matching OS.