### PR TITLE
update to instructions for local development exercise

### DIFF
--- a/docs/3-virtual-machines-containers/3.2-local-development.md
+++ b/docs/3-virtual-machines-containers/3.2-local-development.md
@@ -48,7 +48,6 @@ Read [Creating a Base Box](https://www.vagrantup.com/docs/boxes/base) and [Creat
     ?> Many of Vagrant requirements are already taken care of for you in the example. It is up to you to figure out which one(s) you need to add.
 
 2. Add a [Vagrant `post-processor`](https://www.packer.io/docs/post-processors/vagrant/vagrant) to your Packer build template. Configure it to output both a VMWare Fusion image and a Vagrant box.
-- Add a vagrant post processor to automatically upload your box to your cloud acount
 
 3. Create a VagrantCloud account if needed and upload your box.
 
@@ -60,6 +59,10 @@ Read [Creating a Base Box](https://www.vagrantup.com/docs/boxes/base) and [Creat
 6. Run `vagrant up` and verify Vagrant can pull and start your VM.
 
 7. Verify that `vagrant ssh` will ssh into your VM.
+
+## Extra Credit
+
+ Add a post processor to automatically upload your vagrant box to Vagrant Cloud.
 
 ## Knowledge Check
 

--- a/docs/3-virtual-machines-containers/3.2-local-development.md
+++ b/docs/3-virtual-machines-containers/3.2-local-development.md
@@ -53,7 +53,7 @@ Read [Creating a Base Box](https://www.vagrantup.com/docs/boxes/base) and [Creat
 3. Create a VagrantCloud account if needed and upload your box.
 
 4. Read and install required pieces for the [Vagrant VMWare provider](https://developer.hashicorp.com/vagrant/docs/providers/vmware)
-- Hint: use brew to install vagrant-vmware-desktop
+- Hint: For VMWare Utility use `brew install --cask vagrant-vmware-utility`
 
 5. Create a Vagrant file that will pull your base box from VagrantCloud
 

--- a/docs/3-virtual-machines-containers/3.2-local-development.md
+++ b/docs/3-virtual-machines-containers/3.2-local-development.md
@@ -62,7 +62,7 @@ Read [Creating a Base Box](https://www.vagrantup.com/docs/boxes/base) and [Creat
 
 ## Extra Credit
 
- Add a post processor to automatically upload your vagrant box to Vagrant Cloud.
+ Add a post processor to automatically upload your packer build artifact to Vagrant Cloud.
 
 ## Knowledge Check
 

--- a/docs/3-virtual-machines-containers/3.2-local-development.md
+++ b/docs/3-virtual-machines-containers/3.2-local-development.md
@@ -48,16 +48,19 @@ Read [Creating a Base Box](https://www.vagrantup.com/docs/boxes/base) and [Creat
     ?> Many of Vagrant requirements are already taken care of for you in the example. It is up to you to figure out which one(s) you need to add.
 
 2. Add a [Vagrant `post-processor`](https://www.packer.io/docs/post-processors/vagrant/vagrant) to your Packer build template. Configure it to output both a VMWare Fusion image and a Vagrant box.
+- Add a vagrant post processor to automatically upload your box to your cloud acount
 
 3. Create a VagrantCloud account if needed and upload your box.
 
 4. Read and install required pieces for the [Vagrant VMWare provider](https://developer.hashicorp.com/vagrant/docs/providers/vmware)
+- Hint: use brew to install vagrant-vmware-desktop
 
 5. Create a Vagrant file that will pull your base box from VagrantCloud
 
 6. Run `vagrant up` and verify Vagrant can pull and start your VM.
 
 7. Verify that `vagrant ssh` will ssh into your VM.
+
 
 ## Knowledge Check
 

--- a/docs/3-virtual-machines-containers/3.2-local-development.md
+++ b/docs/3-virtual-machines-containers/3.2-local-development.md
@@ -61,7 +61,6 @@ Read [Creating a Base Box](https://www.vagrantup.com/docs/boxes/base) and [Creat
 
 7. Verify that `vagrant ssh` will ssh into your VM.
 
-
 ## Knowledge Check
 
 <div class="quizdown">


### PR DESCRIPTION
updates exercise instructions to  include a step to add a post-processor to upload box to cloud account, and a hint for installing vagrant-vmware-desktop.