### PR TITLE
Update AWS CLI instructions to use Brew. 

### DIFF
--- a/docs/4-cloud-computing/4.1.1-aws.md
+++ b/docs/4-cloud-computing/4.1.1-aws.md
@@ -64,7 +64,10 @@ Once your are signed in to AWS you can use the web based [console](https://conso
 **Note:** aws-vault is not necessary to use the AWS CLI but adds additional security by storing your credentials in a more secure way.
 
 1. If you do not already have security credentials for your account open [My security credentials](https://console.aws.amazon.com/iam/home?#/security_credentials) in the AWS console; click *Create access key* and download the CSV file or save your credentials someplace safe.
-2. Install the [aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) tool: `curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"` followed by `sudo installer -pkg AWSCLIV2.pkg -target /`
+2. Install the [aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) tool: `brew install awscli`
+
+**Note:** Brew has both v1 and v2 of the AWS CLI, so make sure you install v2.
+
 3. Install [aws-vault](https://github.com/99designs/aws-vault): `brew install --cask aws-vault`
 4. Add your credentials to aws-vault by running `aws-vault add PROFILE_NAME`. **Note:** replace *PROFILE_NAME* with whatever you would like to call your profile. You will be prompted to enter your AWS credentials and then to create a password to protect them.
 5. Test AWS CLI `aws-vault exec PROFILE_NAME -- aws s3 ls`


### PR DESCRIPTION
This section previously instructed the user to manually install the CLI, but this can be done with Brew.  Also, added a note about which version of the AWS CLI to install.  