### PR TITLE
Remove references to aws-vault

### DIFF
--- a/docs/4-cloud-computing/4.1.1-aws.md
+++ b/docs/4-cloud-computing/4.1.1-aws.md
@@ -55,19 +55,13 @@ Once your are signed in to AWS you can use the web based [console](https://conso
 
 ### CLI Setup
 
-?>Here is a helpful Liatrio created document detailing how to setup your [aws-vault credentials](https://liatrio.atlassian.net/wiki/spaces/TOOLS/pages/2455076906/aws-vault).
-
 **Requirements**
 
 - Python 2 version 2.6.5+ or Python 3 version 3.3
 
-**Note:** aws-vault is not necessary to use the AWS CLI but adds additional security by storing your credentials in a more secure way.
-
 1. If you do not already have security credentials for your account open [My security credentials](https://console.aws.amazon.com/iam/home?#/security_credentials) in the AWS console; click *Create access key* and download the CSV file or save your credentials someplace safe.
 2. Install the [aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) tool: `curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"` followed by `sudo installer -pkg AWSCLIV2.pkg -target /`
-3. Install [aws-vault](https://github.com/99designs/aws-vault): `brew install --cask aws-vault`
-4. Add your credentials to aws-vault by running `aws-vault add PROFILE_NAME`. **Note:** replace *PROFILE_NAME* with whatever you would like to call your profile. You will be prompted to enter your AWS credentials and then to create a password to protect them.
-5. Test AWS CLI `aws-vault exec PROFILE_NAME -- aws s3 ls`
+3. Refer to [this document](https://vigilant-adventure-p83913k.pages.github.io/end_user/onboarding/) to gain access to the AWS console through the CLI using SSO.
 
 If this is a new account the output from the last command will be empty but you won't see any errors. The command uses *aws-vault* to execute *aws s3 ls* using the credentials for your profile. *aws s3 ls* lists the s3 buckets your account has access to in your default region.
 


### PR DESCRIPTION
Removed references to working with aws-vault in relation to using the AWS CLI.  Replaced steps 3-5 with a document written by Densell Peters describing how to get set up with SSO on the AWS CLI.