### PR TITLE
docs: updating all dks links to upstream repo

### DIFF
--- a/docs/4-cloud-computing/4.2.6-ecs.md
+++ b/docs/4-cloud-computing/4.2.6-ecs.md
@@ -28,7 +28,7 @@ Checkout this great explanation: [What is the difference between a task and serv
 
 ## Exercise
 
-To get an understanding on how two containers need to communicate with one another, we will be utilizing the [DevOps Knowledge Share UI](https://github.com/liatrio/devops-knowledge-share-dob-ui) application we used before as well as the corresponding [API](https://github.com/liatrio/devops-knowledge-share-dob-api).
+To get an understanding on how two containers need to communicate with one another, we will be utilizing the [DevOps Knowledge Share UI](https://github.com/liatrio/dks-ui) application we used before as well as the corresponding [API](https://github.com/liatrio/dks-api).
 
 1. Start by taking the ui and api listed above and test them locally.
 2. Then containerize them using Docker.

--- a/docs/6-release-management/6.3.1-docker.md
+++ b/docs/6-release-management/6.3.1-docker.md
@@ -24,7 +24,7 @@ Similar to more traditional software artifacts, containerized application images
 
 1. If you haven't already, create a [Dockerhub](https://hub.docker.com/) account, and create your first two repositories, name them `dks_ui` and `dks_api`.
 
-2. Fork the two DevOps Knowledge Share repositories from before, the [UI](https://github.com/liatrio/devops-knowledge-share-dob-ui) and [API](https://github.com/liatrio/devops-knowledge-share-dob-api).
+2. Fork the two DevOps Knowledge Share repositories from before, the [UI](https://github.com/liatrio/dks-ui) and [API](https://github.com/liatrio/dks-api).
 
 3. Using two different `Dockerfiles` build two container images. Make sure to [tag](https://docs.docker.com/engine/reference/commandline/tag/) the images using semantic versioning.
 

--- a/docs/6-release-management/6.3.2-helm.md
+++ b/docs/6-release-management/6.3.2-helm.md
@@ -83,7 +83,7 @@ In this exercise we will get started by installing Helm and creating, installing
 
 ## Exercise 2
 
-In this exercise we will take an existing Helm chart which deploys the [DevOps Knowledge Share API](https://github.com/liatrio/devops-knowledge-share-dob-api).
+In this exercise we will take an existing Helm chart which deploys the [DevOps Knowledge Share API](https://github.com/liatrio/dks-api).
 
 1. If you haven't already, clone the DevOps Bootcamp git repo on your local machine. This exercise will build off of the Helm chart in the `examples/ch6/helm/DKS` folder.
 


### PR DESCRIPTION
This pull request primarily updates the repository links in the documentation files across three different sections. The old links to the DevOps Knowledge Share UI and API repositories have been replaced with the new ones.

Here are the key changes:

* [`docs/4-cloud-computing/4.2.6-ecs.md`](diffhunk://#diff-a94cd3cd964c5d21204a46124a5bcb796c1e00c511ca21f5d8876e300f03d818L31-R31): Updated the links to the DevOps Knowledge Share UI and API repositories in the exercise section.
* [`docs/6-release-management/6.3.1-docker.md`](diffhunk://#diff-00d46c520ea94595391ba39303c9cb2ed1be8e9bcdc5145e900c4e34e8092827L27-R27): Changed the links to the DevOps Knowledge Share UI and API repositories in the instructions for creating Dockerhub repositories.
* [`docs/6-release-management/6.3.2-helm.md`](diffhunk://#diff-c9c79cc499b9381f7b3b62c03264cf90441a4900ece1929cf18a9b66eccefcccL86-R86): Replaced the link to the DevOps Knowledge Share API repository in the second exercise section.