### PR TITLE
feat: Update 6.2.2 for clarity and remove typos

### DIFF
--- a/docs/6-release-management/6.2.2-maven-integration.md
+++ b/docs/6-release-management/6.2.2-maven-integration.md
@@ -47,24 +47,24 @@ This section is designed to give you an introduction into how Maven interacts wi
     - Make sure to update the pom.xml to define the [distribution management](https://maven.apache.org/pom.html#repository) snapshot and release repository definitions to use your local Nexus repository paths.
     - Make sure to update your [settings.xml](https://maven.apache.org/settings.html#servers) with authentication for your Nexus repositories.
     - Take note of which Nexus repository the artifact was deployed to.
-4. Change the version of joda-time to a release version.
+4. Update both projects to release versions (if they aren't already).
 5. Validate the deployments to the Nexus Releases repository worked.
 6. Attempt to deploy that same release version again.
     - Take note of what happened in this attempt.
-7. Bump up the `joda-time` dependency version in the `spring-petclinic` pom.xml to a version that is higher than the latest (*we expect to fail the build doing this*)
-8. Bump up the release version of the `joda-time` repo so it matches the version `spring-petclinic` is now dependent on. Deploy this release to your local Nexus
+7. Bump up the `joda-time` dependency version in the `spring-petclinic` pom.xml to a version that is higher than the latest available in the central repository (*we expect to fail the build doing this*).
+8. Bump up the release version of the `joda-time` repo so it matches the version `spring-petclinic` is now dependent on. Deploy this release to your local Nexus.
 9. Try building `spring-petclinic` again.
    - Did this fix the build? Why not?
-   - Take note of why `spring-petclinic` cannot find that version of `joda-time`
-10. **`Challenge:`** Fix `spring-petclinic` so it pull the `joda-time` dependency at the bumped up from your local Nexus repo.
+   - Take note of why `spring-petclinic` cannot find that version of `joda-time`.
+10. **`Challenge:`** Fix `spring-petclinic` so it pulls the `joda-time` dependency at the bumped up version from your local Nexus repo.
 
 ## Exercise - Maven in GitHub Actions
 
-1. Create GitHub Actions workflow to build and deploy artifacts to Nexus on commits to the remote repository.
-    - Make sure to expose local Nexus with ngrok so GitHub runners can reach it
+1. Create a GitHub Actions workflow to build and deploy artifacts to Nexus on commits to the remote repository.
+    - Make sure to expose local Nexus with ngrok so GitHub runners can reach it.
     - A good starting point is GitHub's [Publish Java packages with Maven](https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven)
     - You can also try to accomplish this with the GitHub Action [Java Maven release](https://github.com/marketplace/actions/java-maven-release)
-2. **`Challenge:`** [Create GitHub Action jobs](https://github.com/marketplace/actions/github-action-build-chain-cross-repo-builds) to build dependent projects build when dependency artifacts are built successfully. (*on successful artifact build of joda-time, the spring-petclinic should get built as well*)
+2. **`Challenge:`** [Create GitHub Action jobs](https://github.com/marketplace/actions/github-action-build-chain-cross-repo-builds) to build dependent artifacts when the artifacts they depend on are built successfully. (*on successful artifact build of joda-time, the spring-petclinic should get built as well*)
 
 ![river image](img6/river_light.svg ':size=100x100 :class=light-mode-icon :alt= river image; light mode')
 ![river image](img6/river_dark.svg ':size=100x100 :class=dark-mode-icon :alt= river image; dark mode')
@@ -78,7 +78,7 @@ This section is designed to give you an introduction into how Maven interacts wi
 
 # Deliverable
 
-Discuss what a release is and how they can be performed.
+Discuss what a release is and how releases can be performed.
 
 Discuss the benefits of plugins such as buildnumber and the benefits of Nexus Maven repo settings for version control of artifacts.
 


### PR DESCRIPTION
Some steps from the first exercise in 6.2.2 were ambiguous, so they have been fleshed out for easier readability.  Fixed some typos and grammatical issues throughout.