### PR TITLE
fix: as to has typo

### DIFF
--- a/docs/7-infrastructure-configuration-management/7.2-ansible.md
+++ b/docs/7-infrastructure-configuration-management/7.2-ansible.md
@@ -72,7 +72,7 @@ all:
         three.example.com:
 ```
 
-This inventory defines a host called *mail.example.com*, a group called *webservers* which has the hosts *foo.example.com* and *bar.example.com* and a group called *dbservers* which as the hosts *one.example.com*, *two.example.com* and *three.example.com*.
+This inventory defines a host called *mail.example.com*, a group called *webservers* which has the hosts *foo.example.com* and *bar.example.com* and a group called *dbservers* which has the hosts *one.example.com*, *two.example.com* and *three.example.com*.
 
 ### Playbooks
 


### PR DESCRIPTION
Fixed a simple typo where 'has' forgot the h.