### PR TITLE
7.1.3 Terraform Modules Version update

### DIFF
--- a/docs/7-infrastructure-configuration-management/7.1.3-terraform-modules.md
+++ b/docs/7-infrastructure-configuration-management/7.1.3-terraform-modules.md
@@ -32,6 +32,27 @@ Read HashiCorp's [Terraform module overview](https://developer.hashicorp.com/ter
 
 ### **Registry Modules**
 
+Before beginning this exercise, modify your terraform "required_version" to "1.8.2" (latest) and your aws provider version to "5.48.0"
+
+```hcl
+terraform {
+    required_providers {
+      aws = {
+        source  = "hashicorp/aws"
+        version = "5.48.0"
+      }
+    }
+
+    backend "s3" {
+      bucket = "<your-bucket-name>"
+      key    = "<bucket-key>"
+      region = "<region>"
+    }
+
+  required_version = "1.8.2"
+}
+```
+
 There are a multitude of registry modules available. For this exercise the modules used are managed by HashiCorp.
 
 ?> Whenever you add a new module to a configuration, Terraform must install the module before it can be used. Both the `terraform get` and `terraform init` commands will install and update modules.
@@ -101,7 +122,7 @@ variable "vpc_tags" {
 ```hcl
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.18.1"
+  version = "5.8.1"
 
   name = var.vpc_name
   cidr = var.vpc_cidr
@@ -117,7 +138,7 @@ module "vpc" {
 
 module "ec2_instance" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "4.3.0"
+  version = "5.6.1"
 
   count = 1
   name  = "my-ec2-cluster-${count.index}"

--- a/docs/7-infrastructure-configuration-management/7.2-ansible.md
+++ b/docs/7-infrastructure-configuration-management/7.2-ansible.md
@@ -72,7 +72,7 @@ all:
         three.example.com:
 ```
 
-This inventory defines a host called *mail.example.com*, a group called *webservers* which has the hosts *foo.example.com* and *bar.example.com* and a group called *dbservers* which as the hosts *one.example.com*, *two.example.com* and *three.example.com*.
+This inventory defines a host called *mail.example.com*, a group called *webservers* which has the hosts *foo.example.com* and *bar.example.com* and a group called *dbservers* which has the hosts *one.example.com*, *two.example.com* and *three.example.com*.
 
 ### Playbooks
 


### PR DESCRIPTION
Update the versions of the "vpc" and "ec2_instance" modules to their latest. Updated the aws_provider version to latest and required_terraform version to latest. Reason: To fix errors depreciation errors in "vpc" module 