### PR TITLE
Updated link for exercise 2, resolves #516

### DIFF
--- a/docs/7-infrastructure-configuration-management/7.2-ansible.md
+++ b/docs/7-infrastructure-configuration-management/7.2-ansible.md
@@ -200,7 +200,7 @@ More relevantly, in order for an Ansible playbook to be idempotent, it must be a
 >
 >[Ansible handlers](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html#handlers)
 >
->[Self-Hosted runners as a service](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html#handlers)
+>[Self-Hosted runners as a service](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/configuring-the-self-hosted-runner-application-as-a-service)
 
 2. Ensure you can successfully rerun your playbook using `vagrant provision`, and that doing so results in the same configuration as running it only once.
 


### PR DESCRIPTION
Currently, the link for learning about self hosted runners uses the same URL as the one above it for Ansible handlers.