### PR TITLE
updated link to devops api

### DIFF
--- a/docs/7-infrastructure-configuration-management/7.1.4-terraform-providers.md
+++ b/docs/7-infrastructure-configuration-management/7.1.4-terraform-providers.md
@@ -76,7 +76,7 @@ Most of the time, you'll be able to find a Terraform provider for the platform y
     - ops (ops resource)
 ```
 
-Since this is a custom API the Ferrets have written, we will also need to make our own custom Terraform provider if we want to use Terraform to manage our resources. Knowing the structure of this API is crucial when attempting to write the provider. Before diving into creating the provider for this API, take some time looking over the [API ReadMe](https://github.com/liatrio/devops-bootcamp/blob/7a7b695f669f13a6894bad2220cf34d5a8785d09/examples/ch6/devops-api/README.md), as well as the accompanying scripts. Try to run the API locally and add some resources until you think you have a good understanding of how it works.
+Since this is a custom API the Ferrets have written, we will also need to make our own custom Terraform provider if we want to use Terraform to manage our resources. Knowing the structure of this API is crucial when attempting to write the provider. Before diving into creating the provider for this API, take some time looking over the [API ReadMe](https://github.com/liatrio/devops-bootcamp/tree/master/examples/ch7/devops-api), as well as the accompanying scripts. Try to run the API locally and add some resources until you think you have a good understanding of how it works.
 
 <div class="quizdown">
     <div id="chapter-7/7.1.4/api-checkpoint.js" ></div>


### PR DESCRIPTION
The previous link to the devops api pointed to a nonexistent branch that could not be accessed.
