### PR TITLE
Fixed typo in exercise 1 of 8.4

### DIFF
--- a/docs/8-kubernetes-container-orchestration/8.4-rbac.md
+++ b/docs/8-kubernetes-container-orchestration/8.4-rbac.md
@@ -87,7 +87,7 @@ stringData:
   password: 'YOUR_PASSWORD'
 ```
 
-5. Setup Jenkins and install the "Kubernetes Credentials Provider" plugin. You should notice a Kubernetes store appear under "Scores Scoped to Jenkins" in the "Credentials" section but your secret above isn't showing up. This is because Jenkins cannot access Kubernetes secrets by default. Having Jenkins access this new secret will require giving it a new role and role binding in Kubernetes.
+5. Setup Jenkins and install the "Kubernetes Credentials Provider" plugin. You should notice a Kubernetes store appear under "Stores Scoped to Jenkins" in the "Credentials" section but your secret above isn't showing up. This is because Jenkins cannot access Kubernetes secrets by default. Having Jenkins access this new secret will require giving it a new role and role binding in Kubernetes.
 ![before secrets image](img8/before-secrets-rbac.svg ':class=img-center :alt= before secrets image')
 
 5. Create a new role for jenkins named "jenkins-read-secrets" in the "jenkins" namespace to read Kubernetes secrets. Use the labels and annotations specified below. Give this role a rule to get/watch/list secrets.


### PR DESCRIPTION
Typo in step 5 of exercise 1 in chapter 8.4. It was previously "Scores Scoped to Jenkins" and is now "Stores Scoped to Jenkins".