### PR TITLE
fix: added 'to'

### DIFF
--- a/docs/8-kubernetes-container-orchestration/8.4-rbac.md
+++ b/docs/8-kubernetes-container-orchestration/8.4-rbac.md
@@ -32,7 +32,7 @@ API Objects for configuring RBAC: Role, ClusterRole, RoleBinding, and ClusterRol
 | Authorization Mode | Description                                                                                                                                                |
 |--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | RBAC               | (Role-based Access Control) is a method of regulating access to computer or network resources based on the roles of individual users within an enterprise. |
-| Node               | Grants permissions kubelets based on the pods they're scheduled to run.                                                                                    |
+| Node               | Grants permissions to kubelets based on the pods they're scheduled to run.                                                                                    |
 | ABAC               | (Attribute-Based Access Control) grants rights to users based on policies that combine attributes together.                                                |
 | Webhook            | Is an HTTP callback; a simple event-notification via HTTP POST.                                                                                            |
 


### PR DESCRIPTION
added a missing 'to' word to the Node description