### PR TITLE
feat: Update version of Jenkins Helm chart and add tip about versions

### DIFF
--- a/docs/8-kubernetes-container-orchestration/8.4-rbac.md
+++ b/docs/8-kubernetes-container-orchestration/8.4-rbac.md
@@ -60,8 +60,9 @@ API Objects for configuring RBAC: Role, ClusterRole, RoleBinding, and ClusterRol
 2. Install Jenkins in the new "jenkins" namespace using helm.
 `helm repo add jenkins https://charts.jenkins.io`<br>
 `helm repo update`<br>
-`helm install jenkins jenkins/jenkins -n jenkins --version 3.10.3`
+`helm install jenkins jenkins/jenkins -n jenkins --version 5.1.26`
    - The name of the chart is jenkins/jenkins - found by running `helm search repo jenkins`.
+   - If you have issues getting your pod up and running, please try updating the chart version.
 
 3. Discovery<br>
 After installing the helm chart for Jenkins, what new roles did it add in the "jenkins" namespace? Role bindings? Service accounts?


### PR DESCRIPTION
In the first exercise for section 8.4, using the previously advised version for the Jenkins Helm chart would lead to issues with the Jenkins pod crashing.  Updating to a later version fixed this issue.  

This PR updates the exercise to recommend the latest known working version and adds a tip to check the Jenkins chart version if issues are experienced with the Jenkins pod.