### PR TITLE
feat: Replace JIRA recommendation with GitHub Projects recommendation

### DIFF
--- a/docs/8-kubernetes-container-orchestration/8.7-hello-k8s.md
+++ b/docs/8-kubernetes-container-orchestration/8.7-hello-k8s.md
@@ -36,7 +36,7 @@ This product can be anything you choose. However, there are some necessary compo
 
 ## Creating Your Own Project
 
-Follow this [documentation](https://www.atlassian.com/software/jira/guides/getting-started/basics) to set up your board and ensure you choose a Scrum template in step 2.
+Please use a project management tool, such as a [GitHub Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects) Kanban board, to organize your project tasks.
 
 ![ticket image](img8/ticket_light.svg ':size=100x100 :class=light-mode-icon :alt= ticket image; light mode')
 ![ticket image](img8/ticket_dark.svg ':size=100x100 :class=dark-mode-icon :alt= ticket image; dark mode')


### PR DESCRIPTION
The Hello K8s project instructions recommend using JIRA for project management, which is no longer recommended to Apprentices.  This PR updates those instructions to recommend GitHub projects instead.  