### PR TITLE
fix: incorrect probe in deliverable question

### DIFF
--- a/docs/8-kubernetes-container-orchestration/8.3-probes.md
+++ b/docs/8-kubernetes-container-orchestration/8.3-probes.md
@@ -129,5 +129,5 @@ Probes provide a uniform interface to manage the health of workloads in a Kubern
 
 ### Deliverables
 
-- Why might you use the same configuration for a startup probe and readiness probe?
+- Why might you use the same configuration for a startup probe and liveness probe?
 - Determine whether liveness probes wait for readiness probes to succeed.


### PR DESCRIPTION
"Why might you use the same configuration for a startup probe and ~readiness~ liveness probe?

Its best practice to ensure liveness probes use endpoints that indicate true failure