### PR TITLE
Sidebar instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1171,7 +1171,7 @@ Use Docker to build and serve the content, but remember to rebuild the Docker im
 - Images should be placed under the root `img` folder and referred to using HTML `<img>` tags
 - H3 header (`###`) should be the default header within a page
 - H2 header (`##`) will appear in the navigation as the page's table of contents
-- To add a new section, add a new file to `docs` such as `x.x-new-section.md`, and then reference it in `docs/_sidebar.md`.  Please note: this will also generate new front matter in `docs/README.md`.
+- To add a new section, add a new file to `docs` such as `x.x-new-section.md`, and then reference it in `docs/_sidebar.md`.  
 
 [Contributors](contributors.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1171,6 +1171,7 @@ Use Docker to build and serve the content, but remember to rebuild the Docker im
 - Images should be placed under the root `img` folder and referred to using HTML `<img>` tags
 - H3 header (`###`) should be the default header within a page
 - H2 header (`##`) will appear in the navigation as the page's table of contents
+- To add a new section, add a new file to `docs`, and then reference it in `docs/_sidebar.md`.  Please note: this will also generate new front matter in `docs/README.md`.   
 
 [Contributors](contributors.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1171,7 +1171,7 @@ Use Docker to build and serve the content, but remember to rebuild the Docker im
 - Images should be placed under the root `img` folder and referred to using HTML `<img>` tags
 - H3 header (`###`) should be the default header within a page
 - H2 header (`##`) will appear in the navigation as the page's table of contents
-- To add a new section, add a new file to `docs`, and then reference it in `docs/_sidebar.md`.  Please note: this will also generate new front matter in `docs/README.md`.   
+- To add a new section, add a new file to `docs` such as `x.x-new-section.md`, and then reference it in `docs/_sidebar.md`.  Please note: this will also generate new front matter in `docs/README.md`.
 
 [Contributors](contributors.md)
 


### PR DESCRIPTION
Adds basic instructions for adding a new section to the Bootcamp and ensuring that it will become visible on the Bootcamp's sidebar menu.  