### PR TITLE
chore: fixing typo and adding hint in VAP section of ch8

### DIFF
--- a/docs/8-kubernetes-container-orchestration/8.6.1-validating-admission-policy.md
+++ b/docs/8-kubernetes-container-orchestration/8.6.1-validating-admission-policy.md
@@ -82,6 +82,8 @@ ValidatingAdmissionPolicy CEL expressions have access to a number of different v
 
 3) Create `validatenamespacequota.yaml` and create an admission policy that verifies deployments are not created or updated with a replica count that exceeds the `NamespaceQuota` `maxReplicas`. This policy needs to use the `NamespaceQuota` resource, do not hard code limits in your expressions.
 
+?> Make sure that you are only using one admission policy and one admission policy binding to manage the deployments in both the development and production namespaces
+
 4) From `examples/ch8/validatingadmissionpolicy` run `kubectl apply -f tests`. Only `valid-dev-deploy` and `valid-prod-deploy` should be created.
 
 5) Your org is going to roll out a required label on all Deployments for `criticality` that should be one of `HIGH|MEDIUM|LOW`. Create a new ValidatingAdmissionPolicy that warns developers if their Deployment is missing this upcoming requirement with the following custom message "Deployments need a label of 'criticality' starting on 1/1/2027 with the values 'HIGH', 'MEDIUM', or 'LOW'""

--- a/examples/ch8/validatingadmissionpolicy/tests/test-deployment4.yaml
+++ b/examples/ch8/validatingadmissionpolicy/tests/test-deployment4.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: invalid-dev-deploy
+  name: invalid-prod-deploy
   namespace: production
 spec:
   replicas: 20


### PR DESCRIPTION
Fixed a typo in one of the tests for exercise 2 of chapter 8.6.1, and added a hint to promote best practices regarding the use of admission policies across different namespaces in Kubernetes.