### PR TITLE
Removed aws-vault deliverable

### DIFF
--- a/docs/4-cloud-computing/4.1.1-aws.md
+++ b/docs/4-cloud-computing/4.1.1-aws.md
@@ -76,4 +76,3 @@ Once your are signed in to AWS you can use the web based [console](https://conso
 ## Deliverables
 
 - Set up AWS CLI and verify you can interact with AWS using it
-- Set up aws-vault to track your credentials for you


### PR DESCRIPTION
Removed the aws-vault deliverable after learning that Josh didn't want it to be there anymore during the 2/05/25 Flywheel standup