### PR TITLE
Added hint for installing Selenium Python bindings

### DIFF
--- a/docs/5-software-development-practices/5.5.2-functional-testing.md
+++ b/docs/5-software-development-practices/5.5.2-functional-testing.md
@@ -38,6 +38,8 @@ We will use Selenium and Python to run a couple functional tests on the bootcamp
 
     Read through the [Selenium Getting Started page](https://selenium-python.readthedocs.io/getting-started.html) to get a brief introduction on how to use Selenium.
 
+?> If you are getting an error when trying to install the Selenium Python bindings, look into Pythons [venv module](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/). 
+
 3. Use the starter code provided to test
     * The link in the bottom right corner of the homepage takes you to [the bootcamp introduction](https://devops-bootcamp.liatr.io/#/1-introduction/1.0-overview)
     * The sidebar toggle button properly hides the sidebar

--- a/docs/5-software-development-practices/5.5.2-functional-testing.md
+++ b/docs/5-software-development-practices/5.5.2-functional-testing.md
@@ -38,7 +38,7 @@ We will use Selenium and Python to run a couple functional tests on the bootcamp
 
     Read through the [Selenium Getting Started page](https://selenium-python.readthedocs.io/getting-started.html) to get a brief introduction on how to use Selenium.
 
-?> If you are getting an error when trying to install the Selenium Python bindings, look into Pythons [venv module](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/). 
+?> If you are getting an error when trying to install the Selenium Python bindings, look into [installing the packages in a virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
 
 3. Use the starter code provided to test
     * The link in the bottom right corner of the homepage takes you to [the bootcamp introduction](https://devops-bootcamp.liatr.io/#/1-introduction/1.0-overview)


### PR DESCRIPTION
I attached this site: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/

I like this one because not only does it walk you through how to do it, but also explains the reasoning: "You benefit from the virtual environment since packages can be installed confidently and will not interfere with another project’s environment"