### PR TITLE
fixed link to instanbul in docs/5-software-development-practices/5.5.4-code-coverage.md

### DIFF
--- a/docs/5-software-development-practices/5.5.4-code-coverage.md
+++ b/docs/5-software-development-practices/5.5.4-code-coverage.md
@@ -14,7 +14,7 @@ docs/5-software-development-practices/5.5.4-code-coverage.md:
 
 # Code Coverage:
 
-Code coverage is the percentage of code which is covered by automated tests. Code coverage measurement simply determines which statements in a body of code have been executed through a test run, and which statements have not. There are many ways to check code coverage and they all vary depending on the language you are using. For the Go language coverage testing is built in so you can use the `go test -cover` command. In many other languages you will have to use a third party tool like [Coveralls](http://www.coveralls.io), [Codecov](http://www.codecov.io), or [Istanbul](http://www.istanbul.js.org).
+Code coverage is the percentage of code which is covered by automated tests. Code coverage measurement simply determines which statements in a body of code have been executed through a test run, and which statements have not. There are many ways to check code coverage and they all vary depending on the language you are using. For the Go language coverage testing is built in so you can use the `go test -cover` command. In many other languages you will have to use a third party tool like [Coveralls](http://www.coveralls.io), [Codecov](http://www.codecov.io), or [Istanbul](https://istanbul.js.org/).
 
 ## Exercise 1:
 


### PR DESCRIPTION
Link to instanbul was broken. Fixed the link so that when pressed it will redirect to the correct website.