### PR TITLE
fix: rearranged 7.1.4 Terraform Providers

### DIFF
--- a/docs/7-infrastructure-configuration-management/7.1.4-terraform-providers.md
+++ b/docs/7-infrastructure-configuration-management/7.1.4-terraform-providers.md
@@ -3,6 +3,13 @@ docs/7-infrastructure-configuration-management/7.1.4-terraform-providers.md:
   category: Infrastructure as Code
   estReadingMinutes: 20
   exercises:
+   -
+      name: Hashicups Provider
+      description: Follow the Hashicorp tutorial to understand the parts required for a provider.
+      estMinutes: 180
+      technologies:
+      - Terraform
+      - Go
     -
       name: Provider Boilerplate
       description: Set up the boilerplate for a Terraform provider and test it locally.
@@ -46,9 +53,42 @@ At this point, you should have a good grasp on declaratively defining infrastruc
 
 So far, we've seen Terraform manage resources in different places, such as AWS and Azure. How does Terraform manage to communicate with both of these platforms?
 
-All resources and datasources in Terraform are created by a **provider**. Providers are Terraform plugins that define how resources are declared and how the state of those  resources should be reconciled. Anyone can write a Terraform provider, and providers can be shared publically or privately via provider repositories. This extensibility is part of what makes Terraform so powerful.
+All resources and datasources in Terraform are created by a **provider**. Providers are Terraform plugins that define how resources are declared and how the state of those resources should be reconciled. Anyone can write a Terraform provider, and providers can be shared publically or privately via provider repositories. This extensibility is part of what makes Terraform so powerful.
 
 ?> Take a look at the providers that are published to the [official Terraform repository](https://registry.terraform.io/browse/providers)
+
+### Schemas, Structs, and Types
+
+Before we can write our provider, there are a few things we need to know about the Terraform provider framework.
+
+Generally, Terraform providers try to adhere to the structure of CRUD operations. This means that providers attempt to classify API functionality into 4 groups:
+
+- C[reate]
+  - Creates a new resource
+- R[ead]
+  - Reads an existing resource
+- U[pdate]
+  - Updates an existing resource
+- D[elete]
+  - Deletes an existing resource
+
+In addition to these basic functions, the Terraform provider framework manages data through a schema. A schema defines the metadata and overall "shape" that Terraform can expect to receive when interacting with your API.
+
+Lastly, you'll need to create two separate sets of data structures to hold your data within your provider code:
+
+1. Structures consisting of plain Go types. You'll need these to construct the payloads you'll be sending to the API.
+
+2. Structures consisting of [Terraform types](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/attributes). These are the types that will be in your schema, and are used to handle the data within your Terraform state and plans.
+
+That's a lot of information to digest, and it might not all make sense right now. That's alright, just make sure to keep this information in mind in the upcoming exercises.
+
+### Exercise 1: Hashicups Provider
+
+Hashicorp provides a helpful tutorial to implement a provider for their fictional Hashicups API. This will serve as a good starting point for understanding the pieces required to implement a provider for your own API.
+
+Follow Hashcorp's provided walkthrough on creating a custom provider [here](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider). Begin with the Introduction section and continue through the Testing section.
+
+?> If you're still feeling unsure of what the steps in the tutorial are actually doing, it might be helpful to watch Hashicorp's live Demo where they implement the first few steps of Hashicups [here](https://youtu.be/16qs7LJSyps?si=wqmkZ3hxdoC4vv-8).
 
 ### The DevOps API
 
@@ -76,6 +116,8 @@ Most of the time, you'll be able to find a Terraform provider for the platform y
     - ops (ops resource)
 ```
 
+?> Note that in our API, we can only directly update a resource, and not the resources within it. (eg. You can't update an engineer from its parent dev resource.). Additionally, in our API, when we delete a parent resource, we do not also delete its children.
+
 Since this is a custom API the Ferrets have written, we will also need to make our own custom Terraform provider if we want to use Terraform to manage our resources. Knowing the structure of this API is crucial when attempting to write the provider. Before diving into creating the provider for this API, take some time looking over the [API ReadMe](https://github.com/liatrio/devops-bootcamp/tree/master/examples/ch7/devops-api), as well as the accompanying scripts. Try to run the API locally and add some resources until you think you have a good understanding of how it works.
 
 <div class="quizdown">
@@ -84,7 +126,7 @@ Since this is a custom API the Ferrets have written, we will also need to make o
 
 Now that we have a grasp on what it is we're attempting to have Terraform manage, we can start a deeper discussion of how we can write a Terraform provider to declaratively manage our resources within this API.
 
-### Exercise 1: Provider Boilerplate
+### Exercise 2: Provider Boilerplate
 
 Creating a Terraform provider is hard. To help mitigate some of the difficulty, Hashicorp provides some boilerplate code to help you get started.
 
@@ -134,38 +176,11 @@ We now have the base for our provider! Next, well need to actually implement it.
 
 To be able to debug your custom terraform provider follow the setup on [Debugging Providers](https://developer.hashicorp.com/terraform/plugin/debugging) (Debugging Providers in VScode may be especially usefull)
 
-### Schemas, Structs, and Types
-
-Before we can write our provider, there are a few things we need to know about the Terraform provider framework.
-
-Generally, Terraform providers try to adhere to the structure of CRUD operations. This means that providers attempt to classify API functionality into 4 groups:
-
-- C[reate]
-  - Creates a new resource
-- R[ead]
-  - Reads an existing resource
-- U[pdate]
-  - Updates an existing resource
-  - Note that in our API, we can only directly update a resource, and not the resources within it. (eg. You can't update an engineer from its parent dev resource.)
-- D[elete]
-  - Deletes an existing resource
-  - Again, note that in our API, when we delete a parent resource, we do not also delete its children.
-
-In addition to these basic functions, the Terraform provider framework manages data through a schema. A schema defines the metadata and overall "shape" that Terraform can expect to receive when interacting with your API.
-
-Lastly, you'll need to create two separate sets of data structures to hold your data within your provider code:
-
-1. Structures consisting of plain Go types. You'll need these to construct the payloads you'll be sending to the API.
-
-2. Structures consisting of [Terraform types](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/attributes). These are the types that will be in your schema, and are used to handle the data within your Terraform state and plans.
-
-That's a lot of information to digest, and it might not all make sense right now. That's alright, just make sure to keep this information in mind in the upcoming exercises.
-
-### Exercise 2: Implement Provider Client
+### Exercise 3: Implement Provider Client
 
 With all of that out of the way, it's time to implement our provider! We'll start by implementing our provider client. This will involve setting up the way we'll actually communicate with our API.
 
-In order to implement our client, we'll be referencing the Hashicorp tutorial ["Configure provider client"](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider-configure) section.
+While we implement our client, be sure to reference the Hashicorp tutorial ["Configure provider client"](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider-configure) section.
 
 A couple of things to keep in mind:
 
@@ -176,9 +191,7 @@ A couple of things to keep in mind:
 
 With these notes in mind, follow the "Configure provider client" section of the Hashicorp tutorial to implement your devops-api client, and return here once you've finished. It might also be helpful to reference the `Schemas, Structs, and Types` portion of this section while working through the tutorial.
 
-?> If you're unsure of how to adapt the tutorial to our API, it might be helpful to walk through the tutorial using the Hashicups API first.
-
-### Exercise 3: Implementing the Engineer Datasource and Resource
+### Exercise 4: Implementing the Engineer Datasource and Resource
 
 At this point, we should have a Terraform provider that will connect to our API and... that's about it! Now we need to make Terraform *do something* with that connection.
 
@@ -190,7 +203,7 @@ While the tutorial is a good place to start in terms of implementing your functi
 
 Also of note, the Hashicorp tutorial creates a coffee data source, but not a resource. This is an uncommon approach-- generally, your datasource should be a 1:1 mirror of a resource. (eg. An engineer resource and engineer datasource)
 
-?> Again, if you're struggling to implement our API, it might be worthwhile to follow the Hashicorp tutorial directly to get a grasp on what they're doing, why they're doing it, and what it accomplishes.
+?> Again, if you're struggling to implement our API, it might be worthwhile to follow the Hashicorp tutorial to get a grasp on what they're doing, why they're doing it, and what it accomplishes.
 
 Once you've finished this, you should be able to declaratively manage your engineer resources in the API through Terraform!
 
@@ -198,11 +211,11 @@ Once you've finished this, you should be able to declaratively manage your engin
     <div id="chapter-7/7.1.4/end-of-engineer-checkpoint.js" ></div>
 </div>
 
-### Exercise 4: Testing
+### Exercise 5: Testing
 
 It's good practice to implement some testing for each of your resources. Since you have a working resource now, you should implement some testing for it. Follow the ["Implement automated testing"](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-acceptance-testing) section of the Hashicorp tutorial to add some acceptance testing to your provider.
 
-### Exercise 5: Do it Again!
+### Exercise 6: Do it Again!
 
 You may have noticed that there are other resources in our API that we haven't implemented. Now that you've experienced managing a resource through your custom provider, go back and implement either the Dev or Ops resource to solidify your learning and get experience implementing a more complex resource!
 

--- a/docs/7-infrastructure-configuration-management/7.1.4-terraform-providers.md
+++ b/docs/7-infrastructure-configuration-management/7.1.4-terraform-providers.md
@@ -3,7 +3,7 @@ docs/7-infrastructure-configuration-management/7.1.4-terraform-providers.md:
   category: Infrastructure as Code
   estReadingMinutes: 20
   exercises:
-   -
+    -
       name: Hashicups Provider
       description: Follow the Hashicorp tutorial to understand the parts required for a provider.
       estMinutes: 180

--- a/docs/README.md
+++ b/docs/README.md
@@ -786,6 +786,14 @@ docs/7-infrastructure-configuration-management/7.1.4-terraform-providers.md:
   category: Infrastructure as Code
   estReadingMinutes: 20
   exercises:
+    - name: Hashicups Provider
+      description: >-
+        Follow the Hashicorp tutorial to understand the parts required for a
+        provider.
+      estMinutes: 180
+      technologies:
+        - Terraform
+        - Go
     - name: Provider Boilerplate
       description: Set up the boilerplate for a Terraform provider and test it locally.
       estMinutes: 120


### PR DESCRIPTION
This includes:
- Moving Schemas, Structs, and Types nearer to the top
- Introducing new first exercise to explicitly do Hashicups tutorial before starting on DevOps API
- Minor flow tweaks throughout the rest to make it make sense with the new ordering


No idea if suggesting bootcamp changes is outside the scope of someone still doing the bootcamp, but figured it was worthwhile to offer up my thoughts on how this section could be better/clearer while it was still fresh in my head.