### PR TITLE
docs: move terraform providers section to top-level 8.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is Liatrio's DevOps Bootcamp - a comprehensive educational resource built with Docsify that covers DevOps fundamentals, practices, and tools. The bootcamp is structured as a static documentation site with interactive elements, exercises, and front-matter metadata for tracking learning metrics.
+
+## Development Commands
+
+### Essential Commands
+
+- `npm install` - Install dependencies
+- `npm start` - Build development version and serve with Docsify on port 3000
+- `npm run serve:docsify` - Serve the documentation site locally
+- `npm run build:dev` - Build development version using webpack
+- `npm run build:prod` - Build production version using webpack
+- `npm run lint` - Run markdown linting across all .md files
+- `npm run refresh-front-matter` - Update the master record with new front-matter from exercises
+
+### Docker Development
+
+- `docker build . -t devops-bootcamp` - Build Docker image
+- `docker run -d -p 3000:3000 --name devops-bootcamp devops-bootcamp` - Run container
+- `docker compose up -d` - Start with Docker Compose
+- `docker compose down` - Stop Docker Compose
+
+## Architecture & Structure
+
+### Content Organization
+
+- **docs/** - Main documentation content organized by chapters (1-10)
+  - Each chapter covers specific DevOps topics (fundamentals, virtualization, containerization, etc.)
+  - Exercises include front-matter metadata with categories, technologies, and time estimates
+- **src/** - Source code for Docsify plugins and JavaScript functionality
+- **img/** - Static images and assets
+- **examples/** - Code examples referenced in exercises
+
+### Key Components
+
+- **Docsify Configuration**: Uses docsify-cli for serving and building
+- **Webpack**: Handles bundling of JavaScript components
+- **Front-matter System**: YAML metadata in exercises for tracking learning analytics
+- **Interactive Elements**: Quiz components and visualizations using Chart.js
+
+### Front-matter Metadata System
+
+The bootcamp uses a sophisticated front-matter system to track learning metrics:
+- Each exercise has metadata including category, reading time, technologies, and exercises
+- Front-matter is automatically consolidated into `docs/README.md` by a pre-commit hook
+- The system generates statistics and visualizations from this metadata
+- **IMPORTANT**: When adding new exercises, minimize the number of categories and technologies by reusing existing ones from the master record in `docs/README.md`. This ensures meaningful aggregations and consistent data visualization.
+
+## Important Files
+
+- `docs/README.md` - Master record containing all consolidated front-matter data
+- `docs/_sidebar.md` - Navigation structure for the documentation
+- `.husky/front-matter-condenser.js` - Script that manages front-matter consolidation
+- `STYLE.md` - Style guide for content contributors
+
+## Content Guidelines
+
+- Use H3 headers (`###`) as default within pages
+- H2 headers (`##`) appear in navigation as table of contents
+- Images should use HTML `<img>` tags and be placed in the root `img/` folder
+- Front-matter must follow the specified YAML template for exercises
+- Multi-column layouts available using `grid2`, `grid3`, `grid4` CSS classes
+
+## Pre-commit Hooks
+
+- Husky is configured to run front-matter validation before commits
+- The system ensures all exercise metadata is properly consolidated
+- Run `npm run refresh-front-matter` if front-matter validation fails
+
+## Development Workflow
+
+1. Make content changes in appropriate `docs/` subdirectories
+2. Test locally with `npm start`
+3. Lint content with `npm run lint`
+4. Commit changes (pre-commit hooks will validate front-matter)
+5. The front-matter condenser automatically updates the master record if needed

--- a/docs/8-infrastructure-configuration-management/8.3-terraform-providers.md
+++ b/docs/8-infrastructure-configuration-management/8.3-terraform-providers.md
@@ -1,5 +1,5 @@
 ---
-docs/8-infrastructure-configuration-management/8.1.4-terraform-providers.mSince this is a custom API the Ferrets have written, we will also need to make our own custom Terraform provider if we want to use Terraform to manage our resources. Knowing the structure of this API is crucial when attempting to write the provider for this API. Before diving into creating the provider for this API, take some time looking over the [API ReadMe](https://github.com/liatrio/devops-bootcamp/tree/master/examples/ch8/devops-api), as well as the accompanying scripts. Try to run the API locally and add some resources until you think you have a good understanding of how it works.:
+docs/8-infrastructure-configuration-management/8.3-terraform-providers.md:
   category: Infrastructure as Code
   estReadingMinutes: 20
   exercises:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1103,7 +1103,7 @@ docs/8-infrastructure-configuration-management/8.1.3-terraform-modules.md:
       technologies:
         - Terraform
         - AWS S3
-'docs/8-infrastructure-configuration-management/8.1.4-terraform-providers.mSince this is a custom API the Ferrets have written, we will also need to make our own custom Terraform provider if we want to use Terraform to manage our resources. Knowing the structure of this API is crucial when attempting to write the provider for this API. Before diving into creating the provider for this API, take some time looking over the [API ReadMe](https://github.com/liatrio/devops-bootcamp/tree/master/examples/ch8/devops-api), as well as the accompanying scripts. Try to run the API locally and add some resources until you think you have a good understanding of how it works.':
+docs/8-infrastructure-configuration-management/8.3-terraform-providers.md:
   category: Infrastructure as Code
   estReadingMinutes: 20
   exercises:

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -128,8 +128,8 @@
   - [8.1.1 - Terraform Getting Started](8-infrastructure-configuration-management/8.1.1-terraform-getting-started.md)
   - [8.1.2 - Terraform State & Backends](8-infrastructure-configuration-management/8.1.2-terraform-backends.md)
   - [8.1.3 - Terraform Modules](8-infrastructure-configuration-management/8.1.3-terraform-modules.md)
-  - [8.1.4 - Terraform Providers](8-infrastructure-configuration-management/8.1.4-terraform-providers.md)
 - [8.2 - Ansible](8-infrastructure-configuration-management/8.2-ansible.md)
+- [8.3 - Terraform Providers](8-infrastructure-configuration-management/8.3-terraform-providers.md)
 
 - **Chapter 9**
 - [9.0 - Kubernetes Overview](9-kubernetes-container-orchestration/9.0-overview.md)


### PR DESCRIPTION
- Reorganize terraform providers from subsection 8.1.4 to section 8.3
- Update sidebar navigation to reflect new structure
- Update front-matter metadata in README.md for new file path
- Add CLAUDE.md with project development guidance