### PR TITLE
feat: Added a Task/Taskfile section (7.2.6)

### DIFF
--- a/docs/7-release-management/7.2.6-taskfiles.md
+++ b/docs/7-release-management/7.2.6-taskfiles.md
@@ -1,0 +1,73 @@
+---
+docs/7-release-management/7.2.6-taskfiles.md:
+  category: CI/CD
+  estReadingMinutes: 10
+  exercises:
+    -
+      name: Taskfile Exploration
+      description: Explore the Taskfile of a complex project to understand its structure and how tasks are organized. No code writing is required for this exercise, but you should spend time studying and understanding the Taskfile.
+      estMinutes: 45
+      technologies:
+      - Task
+      - Taskfile
+---
+
+# Taskfiles
+
+A Taskfile is a declarative way to define project automation tasks (e.g., `lint`, `test`, `build`, `release`) in a YAML file (`Taskfile.yml`). One popular implementation is [Task](https://taskfile.dev/), a cross-platform task runner.
+
+Taskfiles provide a version-controlled interface for executing common project workflows, similar in purpose to Makefiles and npm scripts. Tasks are defined by name and execute one or more commands in a defined order.
+
+Task executes commands using the system shell, which may differ across operating systems and environments.
+
+## Why use a Taskfile?
+
+Taskfiles are used to standardize local development workflows across a team and to group related commands under well-defined task names. They can be invoked both locally and in CI pipelines, allowing the same automation logic to be reused in multiple contexts. While Task itself runs on multiple operating systems, the commands defined within a Taskfile may still depend on platform-specific tooling or shell behavior and should be written with that in mind.
+
+## Taskfile structure
+
+Task uses `Taskfile.yml` to define tasks and their commands. A minimal example looks like this:
+
+```yaml
+version: '3'
+
+tasks:
+  test:
+    desc: Run unit tests
+    cmds:
+      - go test ./...
+
+  build:
+    desc: Build the application
+    cmds:
+      - go build -o app
+
+  ci:
+    desc: Run the tasks expected in CI
+    deps:
+      - test
+      - build
+```
+
+In this example, `tasks` contains the map of named tasks. Each task defines `cmds` (the commands to run) and may define `deps` (tasks that must run first). Many teams also use `desc` so task listings are self-documenting.
+
+## Practice
+
+Take a bit to look through a more complex Taskfile from an open source project. See how much you can understand.
+
+Here are a few examples:
+
+- [go-task/task](https://github.com/go-task/task/blob/main/Taskfile.yml)
+- [gogs/gogs](https://github.com/gogs/gogs/blob/main/Taskfile.yml)
+- [sourcegraph/doctree](https://github.com/sourcegraph/doctree/blob/main/Taskfile.yml)
+- [ansible/ansible-language-server](https://github.com/ansible/ansible-language-server/blob/main/Taskfile.yml)
+
+## Comparing Taskfiles and Makefiles
+
+Taskfiles and Makefiles both provide task orchestration and dependency ordering, but they differ in approach. Make is built around file targets and timestamps, which can be powerful for compilation workflows and incremental builds, while Task defines dependencies explicitly between named tasks rather than files.
+
+# Deliverable
+
+- When would you choose a Taskfile over a Makefile?
+- How would you use a Taskfile to standardize local developer workflows?
+- How could a CI pipeline call Task tasks to reduce duplication?

--- a/docs/README.md
+++ b/docs/README.md
@@ -1064,6 +1064,20 @@ docs/7-release-management/7.2.5-go-releaser.md:
         - Go Releaser
         - GitHub
         - GitHub Actions
+docs/7-release-management/7.2.6-taskfiles.md:
+  category: CI/CD
+  estReadingMinutes: 10
+  exercises:
+    - name: Taskfile Exploration
+      description: >-
+        Explore the Taskfile of a complex project to understand its structure
+        and how tasks are organized. No code writing is required for this
+        exercise, but you should spend time studying and understanding the
+        Taskfile.
+      estMinutes: 45
+      technologies:
+        - Task
+        - Taskfile
 docs/7-release-management/7.3.1-docker.md:
   category: Container Orchestration
   estReadingMinutes: 10

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -118,6 +118,7 @@
   - [7.2.3 - Make](7-release-management/7.2.3-make.md)
   - [7.2.4 - Npm](7-release-management/7.2.4-npm.md)
   - [7.2.5 - Go Releaser](7-release-management/7.2.5-go-releaser.md)
+  - [7.2.6 - Taskfiles](7-release-management/7.2.6-taskfiles.md)
 - [7.3 - Containers](7-release-management/7.3-containers.md)
   - [7.3.1 - Docker](7-release-management/7.3.1-docker.md)
   - [7.3.2 - Helm](7-release-management/7.3.2-helm.md)


### PR DESCRIPTION
This change adds documentation for Taskfiles to the release management chapter. It introduces what Taskfiles are, how they are structured, and how they can be used in local development and CI workflows. It includes a minimal example and references to real-world Taskfiles for exploration.