### PR TITLE
feat: replaced old Docker tagging exercise with new Semantic Release …

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -98,6 +98,7 @@
     "ndependent",
     "nqzxz",
     "nterface",
+    "octo-sts",
     "octumn",
     "Ollama",
     "Pactionly",

--- a/docs/7-release-management/7.1-versioning.md
+++ b/docs/7-release-management/7.1-versioning.md
@@ -19,19 +19,27 @@ A version is more than just something marketing departments use to hype up a new
 
 Versions can also be used as a shorthand to convey information about the scope of changes in a release. Read about Semantic Versioning at [semver.org](http://semver.org/). Most software projects have dependencies on libraries written outside of that project. Being able to easily differentiate bug and security fixes from new features or breaking changes makes managing those upstream dependencies much easier. Similarly many software platforms rely on an ecosystem of different software projects in which must track how changes in one project affect the others.
 
+# Semantic Release
+
+Semantic Release automates the package release workflow by analyzing commit history to determine the next version number, generate release notes, and publish packages. By following the [Conventional Commits](https://www.conventionalcommits.org/) specification, teams can communicate the intent of changes in a structured way that tooling can act on — removing the need for manual version bumping and reducing human error in the release process.
+
 ## Exercise
 
-1. Create a Dockerfile to build a simple image which outputs some text when run.
-2. Build your image and make sure to use a semantic version as a tag for the image name. See the [docker CLI reference](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t) for information on image tags.
-3. Run your new image using the image tag.
-4. Update your image to change the output text.
-5. Build a new image using a new semantic version tag.
-6. Run your new image. Now run your old image.
+Build an automated release pipeline that versions an application from commit history and publishes a container image to GHCR on every release.
 
-?> What happens when you build an image without a tag?
+1. In your repository settings, configure the repository to only allow squash and rebase merging.
 
-?> If you did not tag your images what would you have to do to run the old image?
+2. Add a GitHub Actions workflow that triggers on `pull_request` events and validates that the PR title conforms to the Conventional Commits specification using [`action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request). Open a test PR with a non-conforming title to verify the check fails, then fix it and confirm it passes.
 
-## Deliverables
+   > Since squash merges use the PR title as the commit message, what does this guarantee about the commit history on `main`?
 
-Find some open source projects and look at how they use versions. Discuss as a group how effective the projects you find are at using version.
+3. Add a workflow that triggers on pushes to `main` and runs `semantic-release` to determine the next version, create a Git tag, and generate a GitHub Release with changelog notes. For security reasons, a GHA workflow cannot trigger another workflow with the default `secrets.GITHUB_TOKEN`. One workaround is to use PATs but this poses security risks and the tokens may need to be rotated manually. A better solution is to use [octo-sts](https://github.com/octo-sts/app) to supply a scoped short-lived token for pushing the tag.
+
+4. Add a workflow that triggers on `v*` tag pushes, builds your container image, and pushes it to GHCR tagged with the version that triggered the workflow.
+
+5. Merge a `fix:` PR and a `feat:` PR and observe how the version tag changes each time. What commit type would trigger a major version bump?
+
+## Hints
+
+1. A [useful guide](https://crispy-chainsaw-8qmzrgy.pages.github.io/) for setting up `octo-sts`.
+2. Some, if not all of these practices can be found in repos in the [Liatrio Org](https://github.com/liatrio).

--- a/docs/7-release-management/7.1-versioning.md
+++ b/docs/7-release-management/7.1-versioning.md
@@ -31,7 +31,7 @@ Build an automated release pipeline that versions an application from commit his
 
 2. Block pull requests that don't use conventional commits in the title.
 
-   > Since squash merges use the PR title as the commit message, what does this guarantee about the commit history on `main`?
+   > What the squash merge uses as a commit message is configurable in GitHub. Which of the available options make(s) sense for what we're trying to do?
 
 3. Make it so that pushes to main generate a Git tag along with a GitHub Release with changelog notes.
 

--- a/docs/7-release-management/7.1-versioning.md
+++ b/docs/7-release-management/7.1-versioning.md
@@ -19,7 +19,7 @@ A version is more than just something marketing departments use to hype up a new
 
 Versions can also be used as a shorthand to convey information about the scope of changes in a release. Read about Semantic Versioning at [semver.org](http://semver.org/). Most software projects have dependencies on libraries written outside of that project. Being able to easily differentiate bug and security fixes from new features or breaking changes makes managing those upstream dependencies much easier. Similarly many software platforms rely on an ecosystem of different software projects in which must track how changes in one project affect the others.
 
-# Semantic Release
+## Semantic Release
 
 Semantic Release automates the package release workflow by analyzing commit history to determine the next version number, generate release notes, and publish packages. By following the [Conventional Commits](https://www.conventionalcommits.org/) specification, teams can communicate the intent of changes in a structured way that tooling can act on — removing the need for manual version bumping and reducing human error in the release process.
 
@@ -27,19 +27,23 @@ Semantic Release automates the package release workflow by analyzing commit hist
 
 Build an automated release pipeline that versions an application from commit history and publishes a container image to GHCR on every release.
 
-1. In your repository settings, configure the repository to only allow squash and rebase merging.
+1. Configure the repository to only allow squash and rebase merging.
 
-2. Add a GitHub Actions workflow that triggers on `pull_request` events and validates that the PR title conforms to the Conventional Commits specification using [`action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request). Open a test PR with a non-conforming title to verify the check fails, then fix it and confirm it passes.
+
+2. Block pull requests that don't use conventional commits in the title.
 
    > Since squash merges use the PR title as the commit message, what does this guarantee about the commit history on `main`?
 
-3. Add a workflow that triggers on pushes to `main` and runs `semantic-release` to determine the next version, create a Git tag, and generate a GitHub Release with changelog notes. For security reasons, a GHA workflow cannot trigger another workflow with the default `secrets.GITHUB_TOKEN`. One workaround is to use PATs but this poses security risks and the tokens may need to be rotated manually. A better solution is to use [octo-sts](https://github.com/octo-sts/app) to supply a scoped short-lived token for pushing the tag.
+3. Make it so that pushes to main generate a Git tag along with a GitHub Release with changelog notes.
 
-4. Add a workflow that triggers on `v*` tag pushes, builds your container image, and pushes it to GHCR tagged with the version that triggered the workflow.
+   > For security reasons, a GHA workflow cannot trigger another workflow with the default `secrets.GITHUB_TOKEN`. One workaround is to use PATs but this poses security risks and the tokens may need to be rotated manually. Can you come up with a better solution? 
+
+4. Now, make it so that a tag being pushed to your repository causes a versioned artifact to be pushed to GHCR.
 
 5. Merge a `fix:` PR and a `feat:` PR and observe how the version tag changes each time. What commit type would trigger a major version bump?
 
 ## Hints
 
-1. A [useful guide](https://crispy-chainsaw-8qmzrgy.pages.github.io/) for setting up `octo-sts`.
+1. a [potential solution](https://github.com/apps/octo-sts) to the token problem.
+
 2. Some, if not all of these practices can be found in repos in the [Liatrio Org](https://github.com/liatrio).

--- a/docs/7-release-management/7.1-versioning.md
+++ b/docs/7-release-management/7.1-versioning.md
@@ -29,14 +29,13 @@ Build an automated release pipeline that versions an application from commit his
 
 1. Configure the repository to only allow squash and rebase merging.
 
-
 2. Block pull requests that don't use conventional commits in the title.
 
    > Since squash merges use the PR title as the commit message, what does this guarantee about the commit history on `main`?
 
 3. Make it so that pushes to main generate a Git tag along with a GitHub Release with changelog notes.
 
-   > For security reasons, a GHA workflow cannot trigger another workflow with the default `secrets.GITHUB_TOKEN`. One workaround is to use PATs but this poses security risks and the tokens may need to be rotated manually. Can you come up with a better solution? 
+   > For security reasons, a GHA workflow cannot trigger another workflow with the default `secrets.GITHUB_TOKEN`. One workaround is to use PATs but this poses security risks and the tokens may need to be rotated manually. Can you come up with a better solution?
 
 4. Now, make it so that a tag being pushed to your repository causes a versioned artifact to be pushed to GHCR.
 


### PR DESCRIPTION
…exercise in 7.1-versioning.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised release management guide to cover Semantic Release: automated versioning from commit history, Conventional Commits enforcement for PR titles, automated changelogs and Git tags on main, publishing versioned artifacts, replacing the old Docker exercise with an automated release-pipeline walkthrough; added hints and observation steps for token setup and repository examples.
* **Chores**
  * Added "octo-sts" to the spell-check dictionary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->