### PR TITLE
fix: Changed ch8 to ch9 in instructions

### DIFF
--- a/docs/9-kubernetes-container-orchestration/9.2-volumes.md
+++ b/docs/9-kubernetes-container-orchestration/9.2-volumes.md
@@ -64,7 +64,7 @@ spec:
       args: ["shuf -i 0-100 -n 1 >> /opt/number.out;"]
 ```
 
-5. Apply this file with `kubectl apply -f examples/ch8/volumes/random-num-pod.yaml`
+5. Apply this file with `kubectl apply -f examples/ch9/volumes/random-num-pod.yaml`
 
 ?> Note: We create our pod definition declaratively. What would deploying this pod using an imperative command look like? If there is time see if you can recreate this pod without a pod-definition.yaml
 
@@ -90,7 +90,7 @@ So far we have seen how to provision a persistent volume statically. However, th
 
 5. To make sure we dynamically provisioned a persistent volume, use the command `kubectl get pv` to confirm it was created and is bound to our pvc.
 
-6. Next we will use a Kubernetes deployment to deploy our Jenkins pod. Navigate to the Jenkins deployment definition in the folder `examples/ch8/volumes/jenkins-deployment.yaml`.
+6. Next we will use a Kubernetes deployment to deploy our Jenkins pod. Navigate to the Jenkins deployment definition in the folder `examples/ch9/volumes/jenkins-deployment.yaml`.
 
 7. Add the required fields to our deployment definition that mounts the data to the previously created pvc. The fields are exactly the same as a pod for adding volume mounts to pvcs.
 
@@ -98,7 +98,7 @@ So far we have seen how to provision a persistent volume statically. However, th
 
 8. Apply your deployment to the cluster.
 
-9. We need a service to expose our Jenkins deployment. Apply the service definition configuration at `examples/ch8/volumes/jenkins-services.yaml`.
+9. We need a service to expose our Jenkins deployment. Apply the service definition configuration at `examples/ch9/volumes/jenkins-services.yaml`.
 
 10. Port-forward the `jenkins` service and access Jenkins through localhost.
 

--- a/docs/9-kubernetes-container-orchestration/9.2-volumes.md
+++ b/docs/9-kubernetes-container-orchestration/9.2-volumes.md
@@ -37,7 +37,7 @@ The high level lifecycle for PVs and PVCs can be broken into a few parts. We fir
 In this exercise we will create a simple PV and PVC.
 
 1. Use Docker Desktop for your cluster.
-2. Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp.git) if you haven't already and apply the simple PV definition yaml example from `examples/ch8/volumes/pv-definition.yaml`
+2. Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp.git) if you haven't already and apply the simple PV definition yaml example from `examples/ch9/volumes/pv-definition.yaml`
 
   !> *This PV utilizes a `hostPath` field, which should not be used in production as it poses security risks. It is acceptable for demonstration purposes.*
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Exercise 1 in the Kubernetes Container Orchestration section to reference the correct chapter 9 example manifests for the Persistent Volume, random-number pod, Jenkins deployment, and Jenkins service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->