### PR TITLE
fix: changed instructions from use Docker Desktops K8s to stand up lo…

### DIFF
--- a/docs/9-kubernetes-container-orchestration/9.2-volumes.md
+++ b/docs/9-kubernetes-container-orchestration/9.2-volumes.md
@@ -36,7 +36,7 @@ The high level lifecycle for PVs and PVCs can be broken into a few parts. We fir
 
 In this exercise we will create a simple PV and PVC.
 
-1. Use Docker Desktop for your cluster.
+1. Stand up a local Kubernetes cluster with a tool like `k3d` or `KinD`.
 2. Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp.git) if you haven't already and apply the simple PV definition yaml example from `examples/ch9/volumes/pv-definition.yaml`
 
   !> *This PV utilizes a `hostPath` field, which should not be used in production as it poses security risks. It is acceptable for demonstration purposes.*
@@ -78,13 +78,14 @@ So far we have seen how to provision a persistent volume statically. However, th
 
 [Jenkins](https://www.jenkins.io/), is a Continuous Delivery tool that is widely used, but is also being replaced by more favorable tools like GitHub Actions.  For this exercise we are not really using Jenkins for its CD capabilities, but just for purposes of demonstration.  It would be valuable for you to be familiar with making/editing pipelines in Jenkins.  They have a plethora of [examples](https://www.jenkins.io/doc/pipeline/examples/) and [documentation](https://www.jenkins.io/doc/) which includes a [guided tour](https://www.jenkins.io/doc/pipeline/tour/getting-started/).
 
-1. Using Docker Desktop create a new namespace `jenkins`
+1. Create a Kubernetes namespace `jenkins`
 
 2. Docker Desktop has a default StorageClass `docker.io/hostpath` that we will be using. Use the command `kubectl get storageclass` to see it. *StorageClasses are cluster scoped so you do not need to supply a namespace for this command*.
+2. Depending on how you stood up your cluster it may include a default StorageClass. Use the command `kubectl get storageclass` to see it. *StorageClasses are cluster scoped so you do not need to supply a namespace for this command*.
 
-3. As a cluster administrator, you need to pre-create a storage class object that developers can use. Create a StorageClass definition yaml that has the provisioner `docker.io/hostpath`, a volumeBindingMode `immediate` and a name of `standard`. Apply your StorageClass definition file to your cluster with `kubectl apply -f storage-class-definition.yaml`.
+3. As a cluster administrator, you need to pre-create a storage class object that developers can use. Create a StorageClass definition yaml that has a volumeBindingMode `immediate` and a name of `standard`. Apply your StorageClass definition file to your cluster with `kubectl apply -f storage-class-definition.yaml`.
 
-?> Note: Creating the storage class object allows the cluster admin to dictate what storage classes are allowed by the cluster. If you tried to dynamically provision a pvc with a storage class other than `docker.io/hostpath` the cluster would reject it.
+?> Note: With local clusters, support for provisioners varies. Make sure thatyour StorageClass uses a provisioner that your cluster supports.
 
 4. Next, create a pvc that will request resources dynamically. Make sure to use the storage class made in the previous step. Name your pvc `pvc-jenkins`. Apply your pvc definition to your cluster with `kubectl apply -f pvc-definition.yaml`.
 

--- a/docs/9-kubernetes-container-orchestration/9.2-volumes.md
+++ b/docs/9-kubernetes-container-orchestration/9.2-volumes.md
@@ -76,37 +76,29 @@ So far we have seen how to provision a persistent volume statically. However, th
 
 ### Jenkins
 
-[Jenkins](https://www.jenkins.io/), is a Continuous Delivery tool that is widely used, but is also being replaced by more favorable tools like GitHub Actions.  For this exercise we are not really using Jenkins for its CD capabilities, but just for purposes of demonstration.  It would be valuable for you to be familiar with making/editing pipelines in Jenkins.  They have a plethora of [examples](https://www.jenkins.io/doc/pipeline/examples/) and [documentation](https://www.jenkins.io/doc/) which includes a [guided tour](https://www.jenkins.io/doc/pipeline/tour/getting-started/).
+[Jenkins](https://www.jenkins.io/) is a Continuous Delivery tool that is widely used, but is also being replaced by more favorable tools like GitHub Actions.  For this exercise we are not really using Jenkins for its CD capabilities, but just for purposes of demonstration.  It would be valuable for you to be familiar with making/editing pipelines in Jenkins.  They have a plethora of [examples](https://www.jenkins.io/doc/pipeline/examples/) and [documentation](https://www.jenkins.io/doc/) which includes a [guided tour](https://www.jenkins.io/doc/pipeline/tour/getting-started/).
 
-1. Create a Kubernetes namespace `jenkins`
+1. Create a Kubernetes namespace `jenkins`.
 
 2. Depending on how you stood up your cluster it may include a default StorageClass. Use the command `kubectl get storageclass` to see it. *StorageClasses are cluster scoped so you do not need to supply a namespace for this command*.
 
-3. As a cluster administrator, you need to pre-create a storage class object that developers can use. Create a StorageClass definition yaml that has a volumeBindingMode `Immediate` and a name of `standard`. Apply your StorageClass definition file to your cluster with `kubectl apply -f storage-class-definition.yaml`.
+3. As a cluster administrator, you may need to pre-create a storage class object that developers can use. If your cluster does not already have a suitable default StorageClass, create one.
 
 ?> Note: With local clusters, support for provisioners varies. Make sure that your StorageClass uses a provisioner that your cluster supports.
 
-4. Next, create a pvc that will request resources dynamically. Make sure to use the storage class made in the previous step. Name your pvc `pvc-jenkins`. Apply your pvc definition to your cluster with `kubectl apply -f pvc-definition.yaml`.
+4. Modify the `jenkins` deployment defined in `jenkins-deployment.yaml` so that it uses a PersistentVolumeClaim to request storage for `/var/jenkins_home`. If needed, create any additional resources required to support dynamic provisioning.
 
-5. To make sure we dynamically provisioned a persistent volume, use the command `kubectl get pv` to confirm it was created and is bound to our pvc.
+5. Apply your deployment to the cluster.
 
-6. Next we will use a Kubernetes deployment to deploy our Jenkins pod. Navigate to the Jenkins deployment definition in the folder `examples/ch9/volumes/jenkins-deployment.yaml`.
+6. Apply the service definition configuration at `examples/ch9/volumes/jenkins-services.yaml`.
 
-7. Add the required fields to our deployment definition that mounts the data to the previously created pvc. The fields are exactly the same as a pod for adding volume mounts to pvcs.
+7. Port-forward the `jenkins` service and access Jenkins through localhost.
 
-?> Hint: The `mountPath` field should be set to `/var/jenkins_home`
+8. Look into the logs for the Jenkins pod in our Jenkins namespace to find the initial Administrator Password.
 
-8. Apply your deployment to the cluster.
+9. Make sure you can access Jenkins and go through the setup process.
 
-9. We need a service to expose our Jenkins deployment. Apply the service definition configuration at `examples/ch9/volumes/jenkins-services.yaml`.
-
-10. Port-forward the `jenkins` service and access Jenkins through localhost.
-
-11. Look into the logs for the Jenkins pod in our Jenkins namespace to find the initial Administrator Password.
-
-12. Make sure you can access Jenkins and go through the setup process.
-
-13. Delete the Jenkins pod. Does the data persist when it is redeployed? You might have to port-forward the service again.
+10. Delete the Jenkins pod. Does the data persist when it is redeployed? After deleting the pod, your port-forward session may terminate because it was connected to the old pod. Re-run the port-forward command to reconnect.
 
 ## Deliverables
 
@@ -114,3 +106,5 @@ So far we have seen how to provision a persistent volume statically. However, th
 - What is the difference between persistent volumes and persistent volume claims?
 - What are the advantages of dynamic provisioning as opposed to static provisioning of pvs?
 - How do storage classes relate to pvs and pvcs?
+- What is the benefit of creating a service vs just port-forwarding the deployment?
+- Would `kubectl port-forward` be used in production?

--- a/docs/9-kubernetes-container-orchestration/9.2-volumes.md
+++ b/docs/9-kubernetes-container-orchestration/9.2-volumes.md
@@ -80,12 +80,11 @@ So far we have seen how to provision a persistent volume statically. However, th
 
 1. Create a Kubernetes namespace `jenkins`
 
-2. Docker Desktop has a default StorageClass `docker.io/hostpath` that we will be using. Use the command `kubectl get storageclass` to see it. *StorageClasses are cluster scoped so you do not need to supply a namespace for this command*.
 2. Depending on how you stood up your cluster it may include a default StorageClass. Use the command `kubectl get storageclass` to see it. *StorageClasses are cluster scoped so you do not need to supply a namespace for this command*.
 
-3. As a cluster administrator, you need to pre-create a storage class object that developers can use. Create a StorageClass definition yaml that has a volumeBindingMode `immediate` and a name of `standard`. Apply your StorageClass definition file to your cluster with `kubectl apply -f storage-class-definition.yaml`.
+3. As a cluster administrator, you need to pre-create a storage class object that developers can use. Create a StorageClass definition yaml that has a volumeBindingMode `Immediate` and a name of `standard`. Apply your StorageClass definition file to your cluster with `kubectl apply -f storage-class-definition.yaml`.
 
-?> Note: With local clusters, support for provisioners varies. Make sure thatyour StorageClass uses a provisioner that your cluster supports.
+?> Note: With local clusters, support for provisioners varies. Make sure that your StorageClass uses a provisioner that your cluster supports.
 
 4. Next, create a pvc that will request resources dynamically. Make sure to use the storage class made in the previous step. Name your pvc `pvc-jenkins`. Apply your pvc definition to your cluster with `kubectl apply -f pvc-definition.yaml`.
 


### PR DESCRIPTION
…cal cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes volumes exercise to use k3d or KinD for local clusters instead of Docker Desktop.
  * Revised StorageClass guidance to check for an existing default and create one only if needed; clarified local provisioner differences.
  * Simplified PVC mounting instructions and deployment/apply flow; added steps for accessing Jenkins via port-forward and retrieving the initial admin password.
  * Expanded deliverables with questions on when to use a Service vs. port-forward and production considerations for port-forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->