### PR TITLE
Fix: change ch8 to ch9 to reflect HPA directory location

### DIFF
--- a/docs/9-kubernetes-container-orchestration/9.5-hpas.md
+++ b/docs/9-kubernetes-container-orchestration/9.5-hpas.md
@@ -40,7 +40,7 @@ An HPA (Horizontal Pod Autoscaler) automatically scales resources like deploymen
 
 1. Using Docker Desktop, install [Metrics Server](https://github.com/kubernetes-sigs/metrics-server#deployment).
 
-2. Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp.git) if you haven't already and apply the deployment and service for a cpu-intensive PHP image using the example from `examples/ch8/hpas/cpu-intense-deploy-svc.yaml`.
+2. Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp.git) if you haven't already and apply the deployment and service for a cpu-intensive PHP image using the example from `examples/ch9/hpas/cpu-intense-deploy-svc.yaml`.
 
 3. Create an HPA with the `kubectl autoscale deployment --help` command that will scale the PHP deployment between 1 and 5 pods when the average CPU usage across pods in the deployment exceeds 65%. The deployment will upgrade its replica set accordingly. It will take a few minutes to come up.
 


### PR DESCRIPTION
Change ch8 to ch9 to reflect where the hpas directory is.

"Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp.git) if you haven't already and apply the deployment and service for a cpu-intensive PHP image using the example from examples/ch8/hpas/cpu-intense-deploy-svc.yaml." 

to 
"Clone the bootcamp repository if you haven't already and apply the deployment and service for a cpu-intensive PHP image using the example from examples/ch9/hpas/cpu-intense-deploy-svc.yaml."

at the link 
https://engineering-bootcamp.liatr.io/#/9-kubernetes-container-orchestration/9.5-hpas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Kubernetes HPA setup documentation to reference an updated example manifest for CPU-intensive PHP deployments and service configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->