### PR TITLE
feat: Add new KEDA excercise

### DIFF
--- a/docs/9-kubernetes-container-orchestration/9.5.1-keda.md
+++ b/docs/9-kubernetes-container-orchestration/9.5.1-keda.md
@@ -57,7 +57,7 @@ A key difference from a native HPA is that a ScaledObject can be driven by **mul
 
 2. Verify the installation by confirming that the KEDA operator, metrics adapter, and webhooks pods are all running in the `keda` namespace.
 
-3. Confirm that the KEDA custom resource definitions are available, including `ScaledObject` and `ScaledJob`, by listing API resources in the keda namespace.
+3. Confirm that the KEDA custom resource definitions are available by listing CRDs in your cluster.
 
 ## Create a ScaledObject
 
@@ -96,7 +96,7 @@ kubectl run -i --tty load-generator --rm --image=busybox --restart=Never -- /bin
 
 ## Decrease Server Load
 
-1. Exit the busybox pod.
+1. Stop the busybox pod.
 
 2. Watch the ScaledObject status with `kubectl get deploy <name> --watch`.
 

--- a/docs/9-kubernetes-container-orchestration/9.5.1-keda.md
+++ b/docs/9-kubernetes-container-orchestration/9.5.1-keda.md
@@ -1,0 +1,126 @@
+---
+docs/9-kubernetes-container-orchestration/9.5.1-keda.md:
+  category: Container Orchestration
+  estReadingMinutes: 15
+  exercises:
+    - name: Install KEDA
+      description: Install KEDA on a local Docker Desktop cluster using the official deployment guide and verify the installation.
+      estMinutes: 60
+      technologies:
+        - Docker
+        - Kubernetes
+        - Helm
+    - name: Create a ScaledObject
+      description: Create a KEDA ScaledObject targeting the php-apache deployment with a CPU trigger and observe the HPA KEDA manages automatically.
+      estMinutes: 60
+      technologies:
+        - Docker
+        - Kubernetes
+    - name: Increase Server Load
+      description: Generate load against the php-apache service and watch KEDA drive replica scaling through the ScaledObject.
+      estMinutes: 30
+      technologies:
+        - Docker
+        - Kubernetes
+    - name: Decrease Server Load
+      description: Remove the load generator and observe KEDA scale the deployment back down.
+      estMinutes: 30
+      technologies:
+        - Docker
+        - Kubernetes
+    - name: ScaledObjects with Multiple Triggers
+      description: Add a Cron trigger alongside the CPU trigger to observe KEDA combining multiple scaling signals in a single ScaledObject.
+      estMinutes: 120
+      technologies:
+        - Docker
+        - Kubernetes
+---
+
+# 9.5.1 KEDA
+
+## KEDA in Kubernetes
+
+KEDA (Kubernetes Event-Driven Autoscaler) extends Kubernetes' native autoscaling capabilities to cover event sources far beyond CPU and memory — queues, streams, databases, HTTP traffic, cron schedules, and more. Rather than replacing the HPA, KEDA works alongside it: when you create a ScaledObject, KEDA provisions and manages an HPA under the hood, enriching it with richer trigger logic pulled from external sources.
+
+The two primary KEDA resources are:
+
+| Resource | Purpose |
+|---|---|
+| ScaledObject | Targets a workload (Deployment, StatefulSet, etc.), defines scaling bounds, and lists one or more triggers |
+| ScaledJob | Same idea, but scales Kubernetes Jobs instead of long-running workloads |
+
+A key difference from a native HPA is that a ScaledObject can be driven by **multiple triggers simultaneously**. KEDA scales up when *any* trigger's threshold is met, and scales down only when *all* triggers have fallen below their thresholds.
+
+## Install KEDA
+
+1. Follow the [KEDA deployment guide](https://keda.sh/docs/2.19/deploy/) to install KEDA on a local cluster. The Helm installation method is recommended.
+
+2. Verify the installation by confirming that the KEDA operator, metrics adapter, and webhooks pods are all running in the `keda` namespace.
+
+3. Confirm that the KEDA custom resource definitions are available, including `ScaledObject` and `ScaledJob`, by listing API resources in the keda namespace.
+
+## Create a ScaledObject
+
+The `php-apache` deployment and service from the [HPAs exercise](9-kubernetes-container-orchestration/9.5-hpas.md) are the target workload for this exercise. Ensure they are running before continuing.
+
+1. If you still have an HPA targeting `php-apache` from the previous exercise, delete it. KEDA will create and manage its own HPA — having two competing HPAs on the same workload will cause conflicts.
+
+2. Using the [KEDA CPU scaler documentation](https://keda.sh/docs/2.19/scalers/cpu/), create a ScaledObject declaratively that fulfills the following:
+    - Targets the `php-apache` Deployment
+    - Allows a minimum of 1 replica and a maximum of 5
+    - Scales when average CPU utilization across the deployment's pods exceeds 65%
+
+3. Apply the ScaledObject and verify KEDA has accepted it with `kubectl get scaledobject`.
+
+4. Run `kubectl get hpa` and locate the HPA that KEDA automatically created. Examine its name and configuration.
+
+## KEDA Troubleshooting
+
+1. Inspect the ScaledObject with `kubectl describe scaledobject <name>`. Look for the `Conditions` section; a `Ready` condition of `True` confirms KEDA has successfully reconciled the resource against its target workload.
+
+2. If the ScaledObject is not ready, check the KEDA operator logs in the `keda` namespace for detailed error output. Common issues include the Metrics Server not being installed or the CPU trigger being unable to retrieve utilization data.
+
+3. Confirm Metrics Server is still healthy — the KEDA CPU scaler depends on it for utilization data, just as the native HPA does.
+
+## Increase Server Load
+
+1. Increase the PHP server load. In a separate terminal window, run:
+
+```bash
+kubectl run -i --tty load-generator --rm --image=busybox --restart=Never -- /bin/sh -c "while sleep 0.01; do wget -q -O- http://php-apache; done"
+```
+
+2. Watch the CPU utilization and replica count with `kubectl get hpa --watch` and `kubectl get deploy php-apache --watch`. Because KEDA creates and manages an HPA under the hood, the `TARGETS` column on that HPA is where live CPU utilization is visible — the same format as in the previous exercise.
+
+3. Notice that the `TARGETS` and `REPLICAS` columns on the KEDA-managed HPA look identical to what a native HPA produces. This is intentional: KEDA drives scaling by setting the desired replica count on the HPA it owns, not by bypassing it. Why do you think Kubernetes was designed this way instead of having KEDA scale deployments directly?
+
+## Decrease Server Load
+
+1. Exit the busybox pod.
+
+2. Watch the ScaledObject status with `kubectl get scaledobject --watch`.
+
+3. After a few minutes, check the number of replicas in the `php-apache` deployment. How does the scale-down cooldown compare to the native HPA?
+
+## ScaledObjects with Multiple Triggers
+
+KEDA's most powerful feature is combining multiple independent triggers on a single ScaledObject. Add a [Cron trigger](https://keda.sh/docs/2.19/scalers/cron/) alongside the existing CPU trigger to demonstrate scheduled scaling without any load generator.
+
+1. Edit your existing ScaledObject with `kubectl edit scaledobject <name>` and add a Cron trigger that:
+    - Uses your local IANA timezone identifier (for example, `America/Los_Angeles`)
+    - Fires within the next few minutes and stays active for a 5-minute window
+    - Targets a desired replica count of 3 during that window
+
+?> Use [crontab.guru](https://crontab.guru/#) to generate and verify your cron expressions. The Cron trigger requires both a `start` and `end` expression in `minute hour * * *` format — run `date '+%M %H'` to get your current time and add a few minutes to each.
+
+2. Watch `kubectl get deploy php-apache --watch` as the scheduled window opens. Does the deployment scale up to 3 replicas without any traffic being sent to it?
+
+3. Allow the cron window to expire and observe the scale-down. Does the deployment stay at the cron-desired count, or does it immediately fall back to the CPU trigger's evaluation?
+
+4. Run `kubectl get hpa` and inspect the HPA KEDA is managing. Does it reflect both triggers in its configuration?
+
+### Deliverables
+
+- Explain how KEDA differs from a native Kubernetes HPA. In what scenarios would you reach for KEDA over a native HPA?
+- Describe what happens when multiple KEDA triggers are active simultaneously — does KEDA honor the highest desired replica count, the lowest, or something else?
+- Does KEDA replace Metrics Server, or does it depend on it? Explain the relationship between the two.

--- a/docs/9-kubernetes-container-orchestration/9.5.1-keda.md
+++ b/docs/9-kubernetes-container-orchestration/9.5.1-keda.md
@@ -98,7 +98,7 @@ kubectl run -i --tty load-generator --rm --image=busybox --restart=Never -- /bin
 
 1. Exit the busybox pod.
 
-2. Watch the ScaledObject status with `kubectl get scaledobject --watch`.
+2. Watch the ScaledObject status with `kubectl get deploy <name> --watch`.
 
 3. After a few minutes, check the number of replicas in the `php-apache` deployment. How does the scale-down cooldown compare to the native HPA?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1429,6 +1429,51 @@ docs/9-kubernetes-container-orchestration/9.5-hpas.md:
       technologies:
         - Docker
         - Kubernetes
+docs/9-kubernetes-container-orchestration/9.5.1-keda.md:
+  category: Container Orchestration
+  estReadingMinutes: 15
+  exercises:
+    - name: Install KEDA
+      description: >-
+        Install KEDA on a local Docker Desktop cluster using the official
+        deployment guide and verify the installation.
+      estMinutes: 60
+      technologies:
+        - Docker
+        - Kubernetes
+        - Helm
+    - name: Create a ScaledObject
+      description: >-
+        Create a KEDA ScaledObject targeting the php-apache deployment with a
+        CPU trigger and observe the HPA KEDA manages automatically.
+      estMinutes: 60
+      technologies:
+        - Docker
+        - Kubernetes
+    - name: Increase Server Load
+      description: >-
+        Generate load against the php-apache service and watch KEDA drive
+        replica scaling through the ScaledObject.
+      estMinutes: 30
+      technologies:
+        - Docker
+        - Kubernetes
+    - name: Decrease Server Load
+      description: >-
+        Remove the load generator and observe KEDA scale the deployment back
+        down.
+      estMinutes: 30
+      technologies:
+        - Docker
+        - Kubernetes
+    - name: ScaledObjects with Multiple Triggers
+      description: >-
+        Add a Cron trigger alongside the CPU trigger to observe KEDA combining
+        multiple scaling signals in a single ScaledObject.
+      estMinutes: 120
+      technologies:
+        - Docker
+        - Kubernetes
 docs/9-kubernetes-container-orchestration/9.6-webhooks.md:
   category: Container Orchestration
   estReadingMinutes: 15

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -145,6 +145,7 @@
 - [9.3 - Probes](9-kubernetes-container-orchestration/9.3-probes.md)
 - [9.4 - RBAC](9-kubernetes-container-orchestration/9.4-rbac.md)
 - [9.5 - HPAs](9-kubernetes-container-orchestration/9.5-hpas.md)
+  - [9.5.1 - KEDA](9-kubernetes-container-orchestration/9.5.1-keda.md)
 - [9.6 - Webhooks](9-kubernetes-container-orchestration/9.6-webhooks.md)
   - [9.6.1  - Native Admission Control](9-kubernetes-container-orchestration/9.6.1-validating-admission-policy.md)
 - [9.7 - Declarative Configuration](9-kubernetes-container-orchestration/9.7-declarative-configuration.md)


### PR DESCRIPTION
Adds a new exercise under HPAs introducing KEDA. Covers installation, ScaledObjects with a CPU trigger, load testing, and combining a Cron trigger to show event-driven scaling beyond what native HPAs support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Kubernetes course module on KEDA with structured metadata and estimated reading time.
  * Included step-by-step KEDA exercises: install, verify operator/CRDs, create CPU-triggered ScaledObject, generate load, observe scaling, and troubleshoot.
  * Added guidance for combining triggers (CPU + Cron), validating behavior, and updated navigation to include the new KEDA section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->