### PR TITLE
fix: grammatical error in "The Tao of Liatrio is [the values]..." to …

### DIFF
--- a/docs/1-introduction/1.2-liatrio-and-devops.md
+++ b/docs/1-introduction/1.2-liatrio-and-devops.md
@@ -44,7 +44,7 @@ DevOps practices aim to take the pain out of software delivery and deployment.
 
 ## The Tao
 
-The Tao of Liatrio is the foundational values that guide our work, vision, strategy, and delivery for ourselves and our clients. We carry these philosophies in mind at all times to guide our decision making, inspire us to always bring our best selves, and to understand why we work the way we do.
+The Tao of Liatrio is the set of foundational values that guide our work, vision, strategy, and delivery for ourselves and our clients. We carry these philosophies in mind at all times to guide our decision making, inspire us to always bring our best selves, and to understand why we work the way we do.
 
 ### Become an Ally for Our Customers
 


### PR DESCRIPTION
…"[the *set of* values]..."

This is a case of subject-verb agreement mismatch.
```
Subject: "The Tao" (singular)
Verb:    "is"      (singular)
Object:  "values"  (plural)
```
Prefacing "values" with "the set of" makes the object singular, which contains multitudes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity in introduction documentation with refined phrasing to enhance readability and precision of concepts presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->