### PR TITLE
Fixed in page hyperlinks to 3.3 subsections

### DIFF
--- a/docs/3-AI-Engineering/3.3-best-practices.md
+++ b/docs/3-AI-Engineering/3.3-best-practices.md
@@ -19,11 +19,11 @@ This section explores:
 
 ## Subsections
 
-### [3.3.1 Advanced AI Techniques](3.3.1-agentic-best-practices.md)
+### [3.3.1 Advanced AI Techniques](3-AI-Engineering/3.3.1-agentic-best-practices.md)
 
 Learn senior engineering techniques for leveraging AI in your development workflow, including structured approaches to using LLMs while maintaining engineering oversight.
 
-### [3.3.2 Agentic IDEs](3.3.2-agentic-ide.md)
+### [3.3.2 Agentic IDEs](3-AI-Engineering/3.3.2-agentic-ide.md)
 
 Explore how agentic IDEs represent the next evolution of development environments, integrating AI capabilities directly into the coding workflow.
 

--- a/docs/3-AI-Engineering/3.3-best-practices.md
+++ b/docs/3-AI-Engineering/3.3-best-practices.md
@@ -19,11 +19,11 @@ This section explores:
 
 ## Subsections
 
-### [3.3.1 Advanced AI Techniques](3-AI-Engineering/3.3.1-agentic-best-practices.md)
+### [3.3.1 Advanced AI Techniques](/3-AI-Engineering/3.3.1-agentic-best-practices.md)
 
 Learn senior engineering techniques for leveraging AI in your development workflow, including structured approaches to using LLMs while maintaining engineering oversight.
 
-### [3.3.2 Agentic IDEs](3-AI-Engineering/3.3.2-agentic-ide.md)
+### [3.3.2 Agentic IDEs](/3-AI-Engineering/3.3.2-agentic-ide.md)
 
 Explore how agentic IDEs represent the next evolution of development environments, integrating AI capabilities directly into the coding workflow.
 

--- a/docs/3-AI-Engineering/3.3.2-agentic-ide.md
+++ b/docs/3-AI-Engineering/3.3.2-agentic-ide.md
@@ -162,7 +162,7 @@ Workflows can be triggered through command palettes or custom keybindings, makin
 
 ## Exercise 1 - Structured MCP Server Development with SDD
 
-This exercise applies the SDD (Spec-Driven Development) methodology you learned in [3.3.1 AI Development for Software Engineers](3.3.1-agentic-best-practices.md) to build an MCP server with AI assistance. Rather than exploratory "vibing," you'll follow a structured four-stage workflow: Generate Specification → Task Breakdown → Execute with Management → Validate Implementation.
+This exercise applies the SDD (Spec-Driven Development) methodology you learned in [3.3.1 AI Development for Software Engineers](/3-AI-Engineering/3.3.1-agentic-best-practices.md) to build an MCP server with AI assistance. Rather than exploratory "vibing," you'll follow a structured four-stage workflow: Generate Specification → Task Breakdown → Execute with Management → Validate Implementation.
 
 This structured approach helps you manage complexity, track progress, prevent context rot, and create verifiable proof of functionality at each stage.
 
@@ -177,7 +177,7 @@ Before diving into the exercise, keep these context management practices in mind
 - **Progressive Disclosure**: Load MCP documentation on-demand rather than front-loading everything. Reference the [MCP Full Text](https://modelcontextprotocol.io/llms-full.txt) and [Python MCP SDK](https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/refs/heads/main/README.md) as needed during development
 - **Avoid Context Rot**: The 40%+ utilization "dumb zone" causes performance degradation. Stay aware of this threshold and compact proactively
 
-For detailed coverage of these concepts, see [3.1.4 AI Best Practices](3.1.4-ai-best-practices.md#understanding-context-windows).
+For detailed coverage of these concepts, see [3.1.4 AI Best Practices](/3-AI-Engineering/3.1.4-ai-best-practices.md#understanding-context-windows).
 
 ### Proof Artifacts
 
@@ -310,7 +310,7 @@ Follow the same four-stage SDD workflow from Exercise 1:
 13. **Review Proof Artifacts**: Ensure all evidence demonstrates required functionality
 14. **Document Learnings**: Compare your experience with Exercise 1—what worked better in Windsurf? What was more challenging?
 
-**Key Reflection**: As you work through this exercise, note how the SDD methodology remains consistent even as the development environment changes. The structured approach you learned in [3.3.1 AI Development for Software Engineers](3.3.1-agentic-best-practices.md) applies universally across tools.
+**Key Reflection**: As you work through this exercise, note how the SDD methodology remains consistent even as the development environment changes. The structured approach you learned in [3.3.1 AI Development for Software Engineers](/3-AI-Engineering/3.3.1-agentic-best-practices.md) applies universally across tools.
 
 ## Deliverables
 


### PR DESCRIPTION
Hyperlinks would work when looking at the markdown on github, but not on the rendered page. It would result in a 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated the AI Engineering best-practices page to present the two “3.3” subsections with explicitly formatted, linked headings to their corresponding detailed sections.
  * Revised several internal documentation references in the “3.3.2” agentic IDE guide to use absolute link paths for more reliable navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->