### PR TITLE
docs: update docker compose note

### DIFF
--- a/docs/4-virtual-machines-containers/4.5.1-docker-compose.md
+++ b/docs/4-virtual-machines-containers/4.5.1-docker-compose.md
@@ -18,7 +18,7 @@ docs/4-virtual-machines-containers/4.5.1-docker-compose.md:
 
 [Docker Compose](https://docs.docker.com/compose/) manages multiple Docker containers using a single `docker-compose.yml` configuration file. With it, you can build and run an entire environment using just the `docker compose up` command. Sound familiar to any other tools you've used lately? The configuration options correlate directly with arguments used with the Docker CLI which makes it an easy tool to start using as you're getting familiar with Docker. It lacks features needed for complicated environments but has some very useful use cases.
 
-?> As of Docker Desktop version 3.4.0, the new [Compose V2](https://docs.docker.com/compose/cli-command/) integrates compose commands into the Docker CLI. As of June 2023, the `docker-compose` command is no longer supported on Docker Desktop and has been replaced with `docker compose` (the '-' is replaced with a space). The command can be used after installing Docker Desktop, no longer requiring a separate installation.
+?> The Docker CLI uses a modular plugin based architecture, with Compose being an optional add-on. If you're using Docker Desktop this plugin is included by default. If you're not using Docker Desktop then the Compose plugin can be installed using the `docker-compose` Homebrew formula. Be sure to follow the post-installation instructions to properly register the plugin and make the `docker compose` command available.
 
 ## Use Cases
 

--- a/docs/4-virtual-machines-containers/4.5.1-docker-compose.md
+++ b/docs/4-virtual-machines-containers/4.5.1-docker-compose.md
@@ -18,7 +18,7 @@ docs/4-virtual-machines-containers/4.5.1-docker-compose.md:
 
 [Docker Compose](https://docs.docker.com/compose/) manages multiple Docker containers using a single `docker-compose.yml` configuration file. With it, you can build and run an entire environment using just the `docker compose up` command. Sound familiar to any other tools you've used lately? The configuration options correlate directly with arguments used with the Docker CLI which makes it an easy tool to start using as you're getting familiar with Docker. It lacks features needed for complicated environments but has some very useful use cases.
 
-?> The Docker CLI uses a modular plugin based architecture, with Compose being an optional add-on. If you're using Docker Desktop this plugin is included by default. If you're not using Docker Desktop then the Compose plugin can be installed using the `docker-compose` Homebrew formula. Be sure to follow the post-installation instructions to properly register the plugin and make the `docker compose` command available.
+?> The Docker CLI uses a modular plugin based architecture, with Compose being an optional add-on. If you're using Docker Desktop this plugin is included by default. If you're not using Docker Desktop, the Compose plugin can be installed using the `docker-compose` Homebrew formula. Be sure to follow the post-installation instructions to properly register the plugin and make the `docker compose` command available.
 
 ## Use Cases
 


### PR DESCRIPTION
## Why?
Section 4.5.1 both contains irrelevant historical information about Docker Compose and assumes apprentices are using Docker Desktop. The former is no longer needed and the latter is no longer true. The new version should help make it more clear to people how to properly install and use Docker Compose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Docker Compose guidance to explain how Compose is integrated into the Docker CLI via an optional plugin.
  * Clarified that Compose is included with Docker Desktop by default.
  * Added instructions to install Compose separately via Homebrew and register the plugin to enable `docker compose`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->