### PR TITLE
chore: rename repo URLs + rebrand remaining devops-bootcamp references (#827)

### DIFF
--- a/.github/prompts/new-section.prompt.md
+++ b/.github/prompts/new-section.prompt.md
@@ -74,7 +74,7 @@ An HPA (Horizontal Pod Autoscaler) automatically scales resources like deploymen
 
 1. Using Docker Desktop, install [Metrics Server](https://github.com/kubernetes-sigs/metrics-server#deployment).
 
-2. Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp.git) if you haven't already and apply the deployment and service for a cpu-intensive PHP image using the example from `examples/ch8/hpas/cpu-intense-deploy-svc.yaml`.
+2. Clone the [bootcamp repository](https://github.com/liatrio/engineering-bootcamp.git) if you haven't already and apply the deployment and service for a cpu-intensive PHP image using the example from `examples/ch8/hpas/cpu-intense-deploy-svc.yaml`.
 
 3. Create an HPA with the `kubectl autoscale deployment --help` command that will scale the PHP deployment between 1 and 5 pods when the average CPU usage across pods in the deployment exceeds 65%. The deployment will upgrade its replica set accordingly. It will take a few minutes to come up.
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,9 +1,9 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: devops-bootcamp
+  name: engineering-bootcamp
   annotations:
-    github.com/project-slug: liatrio/devops-bootcamp
+    github.com/project-slug: liatrio/engineering-bootcamp
 spec:
   type: documentation
   lifecycle: production

--- a/docs/11-application-development/11.2.1-solid-principles.md
+++ b/docs/11-application-development/11.2.1-solid-principles.md
@@ -832,7 +832,7 @@ Test your understanding of the SOLID principles:
 
 This exercise provides a complete Python project with a monolithic `ReportGenerator` class that violates SRP by handling data validation, statistics calculation, HTML formatting, and file writing all in one class.
 
-**Project Location**: [examples/ch11/solid-exercises/exercise-1-srp/](https://github.com/liatrio/devops-bootcamp/tree/master/examples/ch11/solid-exercises/exercise-1-srp/)
+**Project Location**: [examples/ch11/solid-exercises/exercise-1-srp/](https://github.com/liatrio/engineering-bootcamp/tree/master/examples/ch11/solid-exercises/exercise-1-srp/)
 
 1. Refactor the `ReportGenerator` class into multiple classes, each with a single responsibility.
 2. Ensure that the behavior-based tests pass after refactoring.
@@ -842,7 +842,7 @@ This exercise provides a complete Python project with a monolithic `ReportGenera
 
 This exercise provides a complete Python project with a `DiscountCalculator` class that violates OCP by using if/elif chains to handle different customer types. Each new customer type requires modifying the existing class.
 
-**Project Location**: [examples/ch11/solid-exercises/exercise-2-ocp/](https://github.com/liatrio/devops-bootcamp/tree/master/examples/ch11/solid-exercises/exercise-2-ocp/)
+**Project Location**: [examples/ch11/solid-exercises/exercise-2-ocp/](https://github.com/liatrio/engineering-bootcamp/tree/master/examples/ch11/solid-exercises/exercise-2-ocp/)
 
 1) Refactor the `DiscountCalculator` to use polymorphism so new customer types can be added without modifying existing code.
 2) Ensure that the behavior-based tests pass after refactoring.
@@ -852,7 +852,7 @@ This exercise provides a complete Python project with a `DiscountCalculator` cla
 
 This exercise provides a complete Python project with a `NotificationService` class that violates DIP by directly instantiating its dependencies (`SMTPClient`, `TwilioClient`). This makes the class hard to test and impossible to configure with different implementations.
 
-**Project Location**: [examples/ch11/solid-exercises/exercise-3-dip/](https://github.com/liatrio/devops-bootcamp/tree/master/examples/ch11/solid-exercises/exercise-3-dip/)
+**Project Location**: [examples/ch11/solid-exercises/exercise-3-dip/](https://github.com/liatrio/engineering-bootcamp/tree/master/examples/ch11/solid-exercises/exercise-3-dip/)
 
 1. Refactor the `NotificationService` to use dependency injection and depend on abstractions (e.g., `NotificationSender` protocol).
 2. Create `SMTPNotificationSender` and `TwilioNotificationSender` classes that implement the `NotificationSender` protocol.

--- a/docs/3-AI-Engineering/3.3.1-agentic-best-practices.md
+++ b/docs/3-AI-Engineering/3.3.1-agentic-best-practices.md
@@ -49,7 +49,7 @@ The first stage of Spec-Driven Development transforms a high-level idea into a c
 
 Use a conversational LLM to iteratively refine your idea through a question-based dialogue. The AI should ask one question at a time, building on your previous answers to extract every relevant detail.
 
-**Example Spec Generation Prompt** (adapted for DevOps Bootcamp):
+**Example Spec Generation Prompt** (adapted for Engineering Bootcamp):
 
 ```text
 I need to create a specification for a DevOps automation project. Ask me one question at a time to develop a thorough, step-by-step spec.

--- a/docs/5-cloud-computing/5.2.6-ecs.md
+++ b/docs/5-cloud-computing/5.2.6-ecs.md
@@ -40,7 +40,7 @@ To get an understanding on how containers need to communicate with one another, 
 
 6. Configure your cluster to run the application. Refer to the `docker-compose.yaml` files in `dks-ui` and `dks-api` to get a sense for what each service needs.
 
-?> I recommend standing up your microservices in the following order validating each piece as you go: dks-db, dks-api, then dks-ui. See this example [task definition for dks-db](https://github.com/liatrio/devops-bootcamp/blob/master/examples/ch5/aws/ecs/dks-db-task-definition.json) and the [db init script](https://github.com/liatrio/dks-api/blob/6ee4e6aa87b62e4387d613cbd442863b60d07657/db-resources/0_0_db.sh).
+?> I recommend standing up your microservices in the following order validating each piece as you go: dks-db, dks-api, then dks-ui. See this example [task definition for dks-db](https://github.com/liatrio/engineering-bootcamp/blob/master/examples/ch5/aws/ecs/dks-db-task-definition.json) and the [db init script](https://github.com/liatrio/dks-api/blob/6ee4e6aa87b62e4387d613cbd442863b60d07657/db-resources/0_0_db.sh).
 
 ?> To interconnect services look into [AWS Service Discovery](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/interconnecting-services.html). Managing Service Discovery Namespaces and Services is simpler via the awscli. See the [following for reference](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-service-discovery.html#create-service-discovery-namespace). The Service Discovery Namespace name and the Service Discovery Service name will control the resulting DNS record. This will also dictate what you set for DB_HOST environment variable for the dks-api.
 

--- a/docs/6-software-development-practices/6.5.1-unit-testing.md
+++ b/docs/6-software-development-practices/6.5.1-unit-testing.md
@@ -87,7 +87,7 @@ func TestIndexGitHubRepositoriesByOrg_basic(t *testing.T) {
   {
    Organization: "liatrio",
    Repository: "devops-bootcamp",
-   Url: "https://github.com/liatrio/devops-bootcamp",
+   Url: "https://github.com/liatrio/engineering-bootcamp",
    License: "MIT",
   },
  }
@@ -114,7 +114,7 @@ func TestIndexGitHubRepositoriesByOrg_multiple(t *testing.T) {
   {
    Organization: "liatrio",
    Repository: "devops-bootcamp",
-   Url: "https://github.com/liatrio/devops-bootcamp",
+   Url: "https://github.com/liatrio/engineering-bootcamp",
    License: "MIT",
   },
   {

--- a/docs/6-software-development-practices/6.5.1-unit-testing.md
+++ b/docs/6-software-development-practices/6.5.1-unit-testing.md
@@ -86,7 +86,7 @@ func TestIndexGitHubRepositoriesByOrg_basic(t *testing.T) {
  repos := []*GitHubRepository{
   {
    Organization: "liatrio",
-   Repository: "devops-bootcamp",
+   Repository: "engineering-bootcamp",
    Url: "https://github.com/liatrio/engineering-bootcamp",
    License: "MIT",
   },
@@ -113,7 +113,7 @@ func TestIndexGitHubRepositoriesByOrg_multiple(t *testing.T) {
  repos := []*GitHubRepository{
   {
    Organization: "liatrio",
-   Repository: "devops-bootcamp",
+   Repository: "engineering-bootcamp",
    Url: "https://github.com/liatrio/engineering-bootcamp",
    License: "MIT",
   },

--- a/docs/6-software-development-practices/6.5.2-functional-testing.md
+++ b/docs/6-software-development-practices/6.5.2-functional-testing.md
@@ -48,7 +48,7 @@ We will use Selenium and Python to run a couple functional tests on the bootcamp
 ?> If you are getting an error when trying to install the Selenium Python bindings, look into [installing the packages in a virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
 
 3. Use the starter code provided to test
-    * The link in the bottom right corner of the homepage takes you to [the bootcamp introduction](https://devops-bootcamp.liatr.io/#/1-introduction/1.0-overview)
+    * The link in the bottom right corner of the homepage takes you to [the bootcamp introduction](https://engineering-bootcamp.liatr.io/#/1-introduction/1.0-overview)
     * The sidebar toggle button properly hides the sidebar
 
 ?> Note: the starter code has Firefox selected as the driver. Make sure to either change it or install geckodriver.

--- a/docs/6-software-development-practices/6.5.4-code-coverage.md
+++ b/docs/6-software-development-practices/6.5.4-code-coverage.md
@@ -22,11 +22,11 @@ You will be using [Jest](https://jestjs.io/) to test the code coverage in the pr
 
 The following code is a series of functions written in Javascript (simple.js):
 
-[sampleCode](https://raw.githubusercontent.com/liatrio/devops-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/simple.js ':include :type=code javascript')
+[sampleCode](https://raw.githubusercontent.com/liatrio/engineering-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/simple.js ':include :type=code javascript')
 
 The following code contains the unit tests that will be testing the Javascript functions (simple.test.js):
 
-[testCode](https://raw.githubusercontent.com/liatrio/devops-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/simple.test.js ':include :type=code javascript')
+[testCode](https://raw.githubusercontent.com/liatrio/engineering-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/simple.test.js ':include :type=code javascript')
 
 Please perform the following:
 
@@ -45,7 +45,7 @@ Try redoing the previous steps, but install the files as a developer dependency.
 
 The provided Javascript package.json file will have everything you need in order to pass the Jest tests; however, you will need to add to the file in order to get Jest to check your coverage.
 
-[package](https://raw.githubusercontent.com/liatrio/devops-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/package.json ':include :type=code json')
+[package](https://raw.githubusercontent.com/liatrio/engineering-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/package.json ':include :type=code json')
 
 Inside your package.json file under the “scripts” section, add a section called “coverage” and use the following command
 

--- a/docs/7-release-management/7.2.2-maven-integration.md
+++ b/docs/7-release-management/7.2.2-maven-integration.md
@@ -39,7 +39,7 @@ This section is designed to give you an introduction into how Maven interacts wi
 
 ## Tips
 
-Use containerization for the following exercise, see [examples](https://github.com/liatrio/devops-bootcamp/tree/master/examples/ch7/Dev-Containers).
+Use containerization for the following exercise, see [examples](https://github.com/liatrio/engineering-bootcamp/tree/master/examples/ch7/Dev-Containers).
 
 1. Fork the following repos:
    - [spring-petclinic](https://github.com/liatrio/spring-petclinic)

--- a/docs/8-infrastructure-configuration-management/8.3-terraform-providers.md
+++ b/docs/8-infrastructure-configuration-management/8.3-terraform-providers.md
@@ -133,7 +133,7 @@ Creating a Terraform provider is hard. To help mitigate some of the difficulty, 
 1. Create your own repo containing the Hashicorp provided boilerplate code from their template.
     - To do this, navigate to the [terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding-framework) repo, click "Use this template", "Create a new repository", and fill in the required information (owner and repo name). If you're working as a group on this, make sure to also add each group member as a collaborator.
 
-2. Clone your repo. Navigate to `main.go` and change the provider address from `registry.terraform.io/hashicorp/scaffolding` to `liatr.io/terraform/devops-bootcamp`.
+2. Clone your repo. Navigate to `main.go` and change the provider address from `registry.terraform.io/hashicorp/scaffolding` to `liatr.io/terraform/engineering-bootcamp`.
 
 <div class="quizdown">
     <div id="chapter-8/8.1.4/provider-name-checkpoint.js" ></div>
@@ -153,13 +153,13 @@ Creating a Terraform provider is hard. To help mitigate some of the difficulty, 
 ```go
     terraform {
       required_providers {
-        devops-bootcamp = {
-          source = "liatr.io/terraform/devops-bootcamp"
+        engineering-bootcamp = {
+          source = "liatr.io/terraform/engineering-bootcamp"
         }
       }
     }
 
-    provider "devops-bootcamp" {
+    provider "engineering-bootcamp" {
       # example configuration here
     }
 ```

--- a/docs/8-infrastructure-configuration-management/8.3-terraform-providers.md
+++ b/docs/8-infrastructure-configuration-management/8.3-terraform-providers.md
@@ -118,7 +118,7 @@ Most of the time, you'll be able to find a Terraform provider for the platform y
 
 ?> Note that in our API, we can only directly update a resource, and not the resources within it. (eg. You can't update an engineer from its parent dev resource.). Additionally, in our API, when we delete a parent resource, we do not also delete its children.
 
-Since this is a custom API the Ferrets have written, we will also need to make our own custom Terraform provider if we want to use Terraform to manage our resources. Knowing the structure of this API is crucial when attempting to write the provider. Before diving into creating the provider for this API, take some time looking over the [API ReadMe](https://github.com/liatrio/devops-bootcamp/tree/master/examples/ch8/devops-api), as well as the accompanying scripts. Try to run the API locally and add some resources until you think you have a good understanding of how it works.
+Since this is a custom API the Ferrets have written, we will also need to make our own custom Terraform provider if we want to use Terraform to manage our resources. Knowing the structure of this API is crucial when attempting to write the provider. Before diving into creating the provider for this API, take some time looking over the [API ReadMe](https://github.com/liatrio/engineering-bootcamp/tree/master/examples/ch8/devops-api), as well as the accompanying scripts. Try to run the API locally and add some resources until you think you have a good understanding of how it works.
 
 <div class="quizdown">
     <div id="chapter-8/8.1.4/api-checkpoint.js" ></div>
@@ -139,7 +139,7 @@ Creating a Terraform provider is hard. To help mitigate some of the difficulty, 
     <div id="chapter-8/8.1.4/provider-name-checkpoint.js" ></div>
 </div>
 
-3. Delete the provided `GNUmakefile` and replace it with [this updated Makefile](https://github.com/liatrio/devops-bootcamp/blob/master/examples/ch8/provider-setup/Makefile) and [helper script](https://github.com/liatrio/devops-bootcamp/blob/master/examples/ch8/provider-setup/.make-helper.sh). Run `make init` to initialize your repo.
+3. Delete the provided `GNUmakefile` and replace it with [this updated Makefile](https://github.com/liatrio/engineering-bootcamp/blob/master/examples/ch8/provider-setup/Makefile) and [helper script](https://github.com/liatrio/engineering-bootcamp/blob/master/examples/ch8/provider-setup/.make-helper.sh). Run `make init` to initialize your repo.
 
 4. Ensure that your provider executes correctly by running `go run main.go`. You should see the following output:
 ```bash

--- a/docs/9-kubernetes-container-orchestration/9.2-volumes.md
+++ b/docs/9-kubernetes-container-orchestration/9.2-volumes.md
@@ -37,7 +37,7 @@ The high level lifecycle for PVs and PVCs can be broken into a few parts. We fir
 In this exercise we will create a simple PV and PVC.
 
 1. Stand up a local Kubernetes cluster with a tool like `k3d` or `KinD`.
-2. Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp.git) if you haven't already and apply the simple PV definition yaml example from `examples/ch9/volumes/pv-definition.yaml`
+2. Clone the [bootcamp repository](https://github.com/liatrio/engineering-bootcamp.git) if you haven't already and apply the simple PV definition yaml example from `examples/ch9/volumes/pv-definition.yaml`
 
   !> *This PV utilizes a `hostPath` field, which should not be used in production as it poses security risks. It is acceptable for demonstration purposes.*
 

--- a/docs/9-kubernetes-container-orchestration/9.5-hpas.md
+++ b/docs/9-kubernetes-container-orchestration/9.5-hpas.md
@@ -40,7 +40,7 @@ An HPA (Horizontal Pod Autoscaler) automatically scales resources like deploymen
 
 1. Using Docker Desktop, install [Metrics Server](https://github.com/kubernetes-sigs/metrics-server#deployment).
 
-2. Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp.git) if you haven't already and apply the deployment and service for a cpu-intensive PHP image using the example from `examples/ch9/hpas/cpu-intense-deploy-svc.yaml`.
+2. Clone the [bootcamp repository](https://github.com/liatrio/engineering-bootcamp.git) if you haven't already and apply the deployment and service for a cpu-intensive PHP image using the example from `examples/ch9/hpas/cpu-intense-deploy-svc.yaml`.
 
 3. Create an HPA with the `kubectl autoscale deployment --help` command that will scale the PHP deployment between 1 and 5 pods when the average CPU usage across pods in the deployment exceeds 65%. The deployment will upgrade its replica set accordingly. It will take a few minutes to come up.
 

--- a/docs/9-kubernetes-container-orchestration/9.7-webhooks.md
+++ b/docs/9-kubernetes-container-orchestration/9.7-webhooks.md
@@ -58,7 +58,7 @@ Mutating and validating webhooks are used in conjunction to enforce policy. The 
 This project is for setting up a basic Kubernetes validating Admission
 Controller using python.
 
-1. Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp.git) if you haven't already and navigate to the `examples/ch9/webhooks` folder for this exercise's files.
+1. Clone the [bootcamp repository](https://github.com/liatrio/engineering-bootcamp.git) if you haven't already and navigate to the `examples/ch9/webhooks` folder for this exercise's files.
 
 2. Deploy a KIND cluster with Admission Controller enabled
 

--- a/docs/9-kubernetes-container-orchestration/9.9-controllers.md
+++ b/docs/9-kubernetes-container-orchestration/9.9-controllers.md
@@ -73,7 +73,7 @@ ___
 
 1. In your k3d cluster, create a namespace to use for this exercise, i.e. `kubectl create namespace my-namespae`.
 
-2. Clone the [bootcamp repository](https://github.com/liatrio/devops-bootcamp) if you haven't already, and navigate to the `examples/ch8/controllers` folder, where you will find a skeleton file for a custom controller.
+2. Clone the [bootcamp repository](https://github.com/liatrio/engineering-bootcamp) if you haven't already, and navigate to the `examples/ch8/controllers` folder, where you will find a skeleton file for a custom controller.
 
 3. Create a directory `pod-controller-module`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1746,8 +1746,8 @@ Use Docker to build and serve the content, but remember to rebuild the Docker im
 
 #### Build and Run Docker Container
 
-1. Execute `docker build . -t devops-bootcamp` from the project's root directory to generate a container image
-2. Run `docker run -d -p 3000:3000 --name devops-bootcamp devops-bootcamp` to run a detached Docker container
+1. Execute `docker build . -t engineering-bootcamp` from the project's root directory to generate a container image
+2. Run `docker run -d -p 3000:3000 --name engineering-bootcamp engineering-bootcamp` to run a detached Docker container
 3. Open <http://localhost:3000>
 
 #### Docker Compose

--- a/examples/ch11/data-patterns/active-record/go.mod
+++ b/examples/ch11/data-patterns/active-record/go.mod
@@ -1,4 +1,4 @@
-module github.com/liatrio/devops-bootcamp/examples/ch11/data-patterns/active-record
+module github.com/liatrio/engineering-bootcamp/examples/ch11/data-patterns/active-record
 
 go 1.21
 

--- a/examples/ch11/data-patterns/concurrency/optimistic/go.mod
+++ b/examples/ch11/data-patterns/concurrency/optimistic/go.mod
@@ -1,4 +1,4 @@
-module github.com/liatrio/devops-bootcamp/examples/ch11/data-patterns/concurrency/optimistic
+module github.com/liatrio/engineering-bootcamp/examples/ch11/data-patterns/concurrency/optimistic
 
 go 1.21
 

--- a/examples/ch11/data-patterns/concurrency/pessimistic/go.mod
+++ b/examples/ch11/data-patterns/concurrency/pessimistic/go.mod
@@ -1,4 +1,4 @@
-module github.com/liatrio/devops-bootcamp/examples/ch11/data-patterns/concurrency/pessimistic
+module github.com/liatrio/engineering-bootcamp/examples/ch11/data-patterns/concurrency/pessimistic
 
 go 1.21
 

--- a/examples/ch11/data-patterns/repository-exercise-starter/go.mod
+++ b/examples/ch11/data-patterns/repository-exercise-starter/go.mod
@@ -1,4 +1,4 @@
-module github.com/liatrio/devops-bootcamp/examples/ch11/data-patterns/repository-exercise-starter
+module github.com/liatrio/engineering-bootcamp/examples/ch11/data-patterns/repository-exercise-starter
 
 go 1.21
 

--- a/examples/ch11/data-patterns/repository/go.mod
+++ b/examples/ch11/data-patterns/repository/go.mod
@@ -1,4 +1,4 @@
-module github.com/liatrio/devops-bootcamp/examples/ch11/data-patterns/repository
+module github.com/liatrio/engineering-bootcamp/examples/ch11/data-patterns/repository
 
 go 1.21
 

--- a/examples/ch7/helm/DKS/templates/NOTES.txt
+++ b/examples/ch7/helm/DKS/templates/NOTES.txt
@@ -1,4 +1,4 @@
-DevOps Bootcamp: Anything in this notes file will be displayed when installing this Helm chart
+Engineering Bootcamp: Anything in this notes file will be displayed when installing this Helm chart
 
 1. Once you have all three pods running successfully you will need to run the following command:
 kubectl port-forward svc/backend 8080:8080

--- a/examples/ch8/devops-api/create.go
+++ b/examples/ch8/devops-api/create.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/liatrio/devops-bootcamp/examples/ch7/devops-resources"
+	"github.com/liatrio/engineering-bootcamp/examples/ch7/devops-resources"
 )
 
 func newDevOps(newDevOps devops_resource.DevOps) (*devops_resource.DevOps, error) {

--- a/examples/ch8/devops-api/delete.go
+++ b/examples/ch8/devops-api/delete.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/liatrio/devops-bootcamp/examples/ch7/devops-resources"
+	"github.com/liatrio/engineering-bootcamp/examples/ch7/devops-resources"
 )
 
 func removeEngineerElement(engineers []*devops_resource.Engineer, engineer_id string) ([]*devops_resource.Engineer, error) {

--- a/examples/ch8/devops-api/go.mod
+++ b/examples/ch8/devops-api/go.mod
@@ -4,8 +4,10 @@ go 1.24.0
 
 require (
 	github.com/gin-gonic/gin v1.9.1
-	github.com/liatrio/devops-bootcamp/examples/ch7/devops-resources v0.0.0-20230921193819-569bb9d9dbdd
+	github.com/liatrio/engineering-bootcamp/examples/ch7/devops-resources v0.0.0-00010101000000-000000000000
 )
+
+replace github.com/liatrio/engineering-bootcamp/examples/ch7/devops-resources => ../devops-resources
 
 require (
 	github.com/bytedance/sonic v1.9.1 // indirect

--- a/examples/ch8/devops-api/go.sum
+++ b/examples/ch8/devops-api/go.sum
@@ -33,8 +33,6 @@ github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZX
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
-github.com/liatrio/devops-bootcamp/examples/ch7/devops-resources v0.0.0-20230921193819-569bb9d9dbdd h1:eiG3C02qmeb9b59I0ZRKItggRZ8Yy1YkIHVnY6+A+hA=
-github.com/liatrio/devops-bootcamp/examples/ch7/devops-resources v0.0.0-20230921193819-569bb9d9dbdd/go.mod h1:4/jOK0F/KUFEvemqN4XCD4aVXhAMEZ+VDXR1mPB9CFk=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/examples/ch8/devops-api/main.go
+++ b/examples/ch8/devops-api/main.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/gin-gonic/gin"
-	devops_resource "github.com/liatrio/devops-bootcamp/examples/ch7/devops-resources"
+	devops_resource "github.com/liatrio/engineering-bootcamp/examples/ch7/devops-resources"
 )
 
 // Thread-safe stores for each data type

--- a/examples/ch8/devops-api/main_test.go
+++ b/examples/ch8/devops-api/main_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/gin-gonic/gin"
-	"github.com/liatrio/devops-bootcamp/examples/ch7/devops-resources"
+	"github.com/liatrio/engineering-bootcamp/examples/ch7/devops-resources"
 	"io"
 	"net/http"
 	"net/http/httptest"

--- a/examples/ch8/devops-api/read.go
+++ b/examples/ch8/devops-api/read.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/liatrio/devops-bootcamp/examples/ch7/devops-resources"
+	"github.com/liatrio/engineering-bootcamp/examples/ch7/devops-resources"
 )
 
 func findEngineer_by_Name(engineer_name string) (*devops_resource.Engineer, error) {

--- a/examples/ch8/devops-api/update.go
+++ b/examples/ch8/devops-api/update.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/liatrio/devops-bootcamp/examples/ch7/devops-resources"
+	"github.com/liatrio/engineering-bootcamp/examples/ch7/devops-resources"
 )
 
 // functions to update resources//

--- a/examples/ch8/devops-resources/README.md
+++ b/examples/ch8/devops-resources/README.md
@@ -7,7 +7,7 @@
 ### Example in how the import is call in your go code:
 
 ```go
-import "github.com/liatrio/devops-bootcamp/examples/ch8/devops-resources"
+import "github.com/liatrio/engineering-bootcamp/examples/ch8/devops-resources"
 ```
 
 #### This is how you would pull the module in the default branch [master]
@@ -17,7 +17,7 @@ import "github.com/liatrio/devops-bootcamp/examples/ch8/devops-resources"
 #### Here is an example of how to include the module inside of the go.mod within the terraform provider:
 
 ```go
-require github.com/liatrio/devops-bootcamp/examples/ch8/devops-resource [branch]
+require github.com/liatrio/engineering-bootcamp/examples/ch8/devops-resource [branch]
 ```
 
 #### When you run go mod tidy go will look for the module at the head of the branch you specified in go.mod

--- a/examples/ch8/devops-resources/README.md
+++ b/examples/ch8/devops-resources/README.md
@@ -73,4 +73,4 @@ type DevOps struct {
 ### Why is the module name long and almost looks like a path.
 
 - Go looks for the path in which the package and module is referenced.
-- For this case the repository is github.com(host)/liatrio(owner)/devops-bootcamp(repo)/examples/ch8/devops-resources(path to package)
+- For this case the repository is github.com(host)/liatrio(owner)/engineering-bootcamp(repo)/examples/ch8/devops-resources(path to package)

--- a/examples/ch8/devops-resources/go.mod
+++ b/examples/ch8/devops-resources/go.mod
@@ -1,3 +1,3 @@
-module github.com/liatrio/devops-bootcamp/examples/ch7/devops-resources
+module github.com/liatrio/engineering-bootcamp/examples/ch7/devops-resources
 
 go 1.19

--- a/examples/ch8/provider-setup/Makefile
+++ b/examples/ch8/provider-setup/Makefile
@@ -7,7 +7,7 @@ GOARCH?=$$(go env GOARCH)
 plan: clean init provider resource datasource debug-allCombined
 
 build: main.go generate
-	go $@ -o terraform-provider-devops-bootcamp
+	go $@ -o terraform-provider-engineering-bootcamp
 
 debug-allCombined:
 	terraform -chdir=examples/allCombined init -plugin-dir=../../.plugin-cache
@@ -31,11 +31,11 @@ fmt: main.tf
 
 #makes a directory including making gome directories should they not exist (-p)
 init: clean build
-	@mkdir -p .plugin-cache/liatr.io/terraform/devops-bootcamp/0.0.1/$(GOOS)_$(GOARCH) && \
-	ln -s "${PWD}/terraform-provider-devops-bootcamp" "${PWD}/.plugin-cache/liatr.io/terraform/devops-bootcamp/0.0.1/$(GOOS)_$(GOARCH)/terraform-provider-devops-bootcamp"
+	@mkdir -p .plugin-cache/liatr.io/terraform/engineering-bootcamp/0.0.1/$(GOOS)_$(GOARCH) && \
+	ln -s "${PWD}/terraform-provider-engineering-bootcamp" "${PWD}/.plugin-cache/liatr.io/terraform/engineering-bootcamp/0.0.1/$(GOOS)_$(GOARCH)/terraform-provider-engineering-bootcamp"
 
 clean: 
-	@rm -rf .plugin-cache .terraform .terraform.lock.hcl terraform-provider-devops-bootcamp && \
+	@rm -rf .plugin-cache .terraform .terraform.lock.hcl terraform-provider-engineering-bootcamp && \
 	rm -rf examples/*/*/.terraform* examples/*/.terraform*
 
 provider:

--- a/examples/codeQuality/goExamples/example_test.go
+++ b/examples/codeQuality/goExamples/example_test.go
@@ -7,7 +7,7 @@ func TestIndexGitHubRepositoriesByOrg_basic(t *testing.T) {
     repos := []*GitHubRepository{
         {
             Organization: "liatrio",
-            Repository: "devops-bootcamp",
+            Repository: "engineering-bootcamp",
             Url: "https://github.com/liatrio/engineering-bootcamp",
             License: "MIT",
         },
@@ -29,7 +29,7 @@ func TestIndexGitHubRepositoriesByOrg_multiple(t *testing.T) {
     repos := []*GitHubRepository{
         {
             Organization: "liatrio",
-            Repository: "devops-bootcamp",
+            Repository: "engineering-bootcamp",
             Url: "https://github.com/liatrio/engineering-bootcamp",
             License: "MIT",
         },

--- a/examples/codeQuality/goExamples/example_test.go
+++ b/examples/codeQuality/goExamples/example_test.go
@@ -8,7 +8,7 @@ func TestIndexGitHubRepositoriesByOrg_basic(t *testing.T) {
         {
             Organization: "liatrio",
             Repository: "devops-bootcamp",
-            Url: "https://github.com/liatrio/devops-bootcamp",
+            Url: "https://github.com/liatrio/engineering-bootcamp",
             License: "MIT",
         },
     }
@@ -30,7 +30,7 @@ func TestIndexGitHubRepositoriesByOrg_multiple(t *testing.T) {
         {
             Organization: "liatrio",
             Repository: "devops-bootcamp",
-            Url: "https://github.com/liatrio/devops-bootcamp",
+            Url: "https://github.com/liatrio/engineering-bootcamp",
             License: "MIT",
         },
         {

--- a/examples/codeQuality/jest-mock/github.js
+++ b/examples/codeQuality/jest-mock/github.js
@@ -3,7 +3,7 @@ const { Octokit } = require("octokit");
 /**
  * Fetches public repository info using Octokit.
  * @param {string} owner - The repo owner (e.g., 'liatrio')
- * @param {string} repo - The repo name (e.g., 'devops-bootcamp')
+ * @param {string} repo - The repo name (e.g., 'engineering-bootcamp')
  * @returns {Promise<object>} - The repository info object
  */
 async function getRepoInfo(owner, repo) {

--- a/examples/codeQuality/jest-mock/mock.js
+++ b/examples/codeQuality/jest-mock/mock.js
@@ -40,9 +40,9 @@ async function checkUserName(username, expectedName = "Chris Blackburn") {
   }
 }
 
-//// REPO CHECKS FOR DEVOPS-BOOTCAMP ////
+//// REPO CHECKS FOR ENGINEERING-BOOTCAMP ////
 
-async function checkRepoName(owner, repo, expectedName = "devops-bootcamp") {
+async function checkRepoName(owner, repo, expectedName = "engineering-bootcamp") {
   try {
     const repoInfo = await getRepoInfo(owner, repo);
     if (!repoInfo || !repoInfo.name) {

--- a/examples/codeQuality/selenium-frame.py
+++ b/examples/codeQuality/selenium-frame.py
@@ -9,7 +9,7 @@ class LiatrioBootcampLinkTest(unittest.TestCase):
 
     def test_bootcamp_link(self):
         driver = self.driver
-        driver.get("https://devops-bootcamp.liatr.io")
+        driver.get("https://engineering-bootcamp.liatr.io")
         # check we get expected page title
 
         # find the link to Introduction to DevOps section at the bottom of the page
@@ -28,7 +28,7 @@ class LiatrioBootcampSidebarTest(unittest.TestCase):
 
     def test_bootcamp_sidebar(self):
         driver = self.driver
-        driver.get("https://devops-bootcamp.liatr.io")
+        driver.get("https://engineering-bootcamp.liatr.io")
         # check that the sidebar is shown (HINT: check html body attributes)
 
         # check that there is no CLOSE attribute on the body

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         <script>
             window.$docsify = {
                 name: "Liatrio's Engineering Bootcamp",
-                repo: "liatrio/devops-bootcamp",
+                repo: "liatrio/engineering-bootcamp",
                 loadSidebar: true,
                 basePath: "/docs/",
                 maxLevel: 0,

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                 search: "auto", // default
                 plugins: [
                     EditOnGithubPlugin.create(
-                        "https://github.com/liatrio/devops-bootcamp/tree/master/docs/",
+                        "https://github.com/liatrio/engineering-bootcamp/tree/master/docs/",
                     ),
                 ],
                 pagination: {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/liatrio/devops-bootcamp.git"
+    "url": "git+https://github.com/liatrio/engineering-bootcamp.git"
   },
   "keywords": [
     "devops",
@@ -27,9 +27,9 @@
   "author": "Liatrio",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/liatrio/devops-bootcamp/issues"
+    "url": "https://github.com/liatrio/engineering-bootcamp/issues"
   },
-  "homepage": "https://github.com/liatrio/devops-bootcamp#readme",
+  "homepage": "https://github.com/liatrio/engineering-bootcamp#readme",
   "dependencies": {
     "chart.js": "^4.3.0",
     "chartjs-chart-wordcloud": "^4.2.0",

--- a/src/quizzes/chapter-4/4.4/docker-quiz.js
+++ b/src/quizzes/chapter-4/4.4/docker-quiz.js
@@ -15,9 +15,9 @@ shuffleAnswers: true
 1. [x] A container is a runtime instance of an image
 	> Good. The image is what defines the container and the container is what is actually running
 1. [ ] An image is a runtime instance of a container
-	> Not quite. Refer back to the [Images and Containers](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=images-and-containers) section above
+	> Not quite. Refer back to the [Images and Containers](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=images-and-containers) section above
 1. [ ] The two terms can be used interchangeably
-	> Not quite. Refer back to the [Images and Containers](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=images-and-containers) section above
+	> Not quite. Refer back to the [Images and Containers](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=images-and-containers) section above
 
 # 1/2 - Suppose you need a very specific set of dependencies and packages installed to your container, but no base image exists that has them already installed for you. What problems does this pose? Select all that apply
 
@@ -46,7 +46,7 @@ shuffleAnswers: true
 1. [x] True
 	> Good. This is because the image build will utilize caching to greatly speed up unchanged layers. This is one of Docker's best strengths
 1. [ ] False
-	> Not quite. Refer back to the [Layers](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=layers) section above
+	> Not quite. Refer back to the [Layers](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=layers) section above
 
 # True or False: If you run the same Docker container twice, the start time will be shorter the second time around
 

--- a/src/quizzes/chapter-4/4.5.2/k8s-quiz.js
+++ b/src/quizzes/chapter-4/4.5.2/k8s-quiz.js
@@ -15,7 +15,7 @@ shuffleAnswers: true
 1. [ ] Docker, Kubernetes
 	> Keep in mind that while Kubernetes and Docker Compose handle container orchestration, all Docker does is create containers
 
-# Order the following Kubernetes resources into the correct scopes (highest scope to lowest scope)<br>If you are confused, reread the [Design](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=design) section above.
+# Order the following Kubernetes resources into the correct scopes (highest scope to lowest scope)<br>If you are confused, reread the [Design](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=design) section above.
 
 1. Cluster
 2. Node
@@ -24,7 +24,7 @@ shuffleAnswers: true
 # True or False: Making an invalid command to the Kubernetes API can run the risk of breaking resources in your cluster
 
 1. [ ] True
-	> Not quite. Refer back to the [Design](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=design) section above to get a firmer grasp on how Kubernetes handles changes to the cluster
+	> Not quite. Refer back to the [Design](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=design) section above to get a firmer grasp on how Kubernetes handles changes to the cluster
 1. [x] False
 	> Excellent! The great thing about the Kubernetes engine is that *proposed* changes (your commands) must be validated by an API server before any changes are made to etcd
 
@@ -33,7 +33,7 @@ shuffleAnswers: true
 1. [x] Deployments, Services
 	> Good. These terms are easy to mix up because they deal with similar things, so this is a good item to commit to memory
 1. [ ] Services, Deployments
-	> Not quite. These terms are easy to mix up because they deal with similar things, so don't sweat it. Reread the [Services](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=services) and [Deployments](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=deployments) definitions above to help commit these to memory
+	> Not quite. These terms are easy to mix up because they deal with similar things, so don't sweat it. Reread the [Services](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=services) and [Deployments](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=deployments) definitions above to help commit these to memory
 
 `;
 

--- a/src/quizzes/chapter-5/5.1.1/aws-quiz.js
+++ b/src/quizzes/chapter-5/5.1.1/aws-quiz.js
@@ -9,9 +9,9 @@ shuffleAnswers: true
 1. [x] True
 	> Good. While naming seems like a feature that should be standalone and separate from tags, this A) allows for quick searching of resources and B) allows for a standardized naming method across all resources, regardless of their type
 1. [ ] False
-	> Not quite. Reread the [Names](https://devops-bootcamp.liatr.io/#/5-cloud-computing/5.1.1-aws?id=names) section above
+	> Not quite. Reread the [Names](https://engineering-bootcamp.liatr.io/#/5-cloud-computing/5.1.1-aws?id=names) section above
 
-# From the following list, select all *quality* resource tags<br>If you are confused, refer to [Liatrio's tagging standards](https://devops-bootcamp.liatr.io/#/5-cloud-computing/5.1.1-aws?id=liatrio39s-tagging-standards) above.
+# From the following list, select all *quality* resource tags<br>If you are confused, refer to [Liatrio's tagging standards](https://engineering-bootcamp.liatr.io/#/5-cloud-computing/5.1.1-aws?id=liatrio39s-tagging-standards) above.
 
 - [x] **Owner**=chris-blackburn
 - [x] **Project**=pipeline-initiative

--- a/src/quizzes/chapter-5/5.1.2/azure-quiz.js
+++ b/src/quizzes/chapter-5/5.1.2/azure-quiz.js
@@ -20,7 +20,7 @@ shuffleAnswers: true
 # True or False: You can change the name of a resource in Azure at any time without needing to alter the resource itself.
 
 1. [ ] True
-	> Not quite. Resource names in Azure are immutable by design, meaning they shouldn't/can't be changed. Refer back to the [Resource Naming and Tagging](https://devops-bootcamp.liatr.io/#/4-cloud-computing/4.1.2-azure?id=resource-naming-and-tagging) section above
+	> Not quite. Resource names in Azure are immutable by design, meaning they shouldn't/can't be changed. Refer back to the [Resource Naming and Tagging](https://engineering-bootcamp.liatr.io/#/4-cloud-computing/4.1.2-azure?id=resource-naming-and-tagging) section above
 1. [x] False
 	> Good. Since resource names are immutable, you would need to destroy the resource and recreate it with a different name
 

--- a/src/quizzes/chapter-5/5.2.2/ec2-and-jenkins-quiz.js
+++ b/src/quizzes/chapter-5/5.2.2/ec2-and-jenkins-quiz.js
@@ -52,11 +52,11 @@ shuffleAnswers: true
 1. [x] Controller, Agent
 	> Good. The controller is the original node that delegates work to one or multiple agents
 1. [ ] Agent, Controller
-	> Almost there! Refer back to the [Jenkins Architecture](https://devops-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
+	> Almost there! Refer back to the [Jenkins Architecture](https://engineering-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
 1. [ ] Pipeline, Agent
-	> Not quite. The Jenkins Pipeline refers to the entire process as a whole. Refer back to the [Jenkins Architecture](https://devops-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
+	> Not quite. The Jenkins Pipeline refers to the entire process as a whole. Refer back to the [Jenkins Architecture](https://engineering-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
 1. [ ] Pipeline, Controller
-	> Not quite. The Jenkins Pipeline refers to the entire process as a whole. Refer back to the [Jenkins Architecture](https://devops-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
+	> Not quite. The Jenkins Pipeline refers to the entire process as a whole. Refer back to the [Jenkins Architecture](https://engineering-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
 
 # True or False: You can have agents working together and running in unison across different environments in one Jenkins pipeline
 

--- a/src/quizzes/chapter-8/8.1.4/provider-name-checkpoint.js
+++ b/src/quizzes/chapter-8/8.1.4/provider-name-checkpoint.js
@@ -2,11 +2,11 @@ const rawQuizdown = `
 ---
 shuffleAnswers: true
 ---
-# Based on the provider address \`\`\`liatri.io/terraform/devops-bootcamp\`\`\`, what is the name of your provider?
+# Based on the provider address \`\`\`liatr.io/terraform/engineering-bootcamp\`\`\`, what is the name of your provider?
 
-- [x] devops-bootcamp
-- [ ] liatri.io/terraform/devops-bootcamp
-- [ ] liatri.io
+- [x] engineering-bootcamp
+- [ ] liatr.io/terraform/engineering-bootcamp
+- [ ] liatr.io
 `;
 
 export { rawQuizdown }


### PR DESCRIPTION
## What Changed

Combines the `github.com/liatrio/devops-bootcamp` URL sweep (originally scoped as Spec 04 / task 4.0) with the follow-up rebrand of every remaining `devops-bootcamp` string a website visitor or exercise-follower would see. Two commits on the branch:

1. **`chore: update repo URL references to engineering-bootcamp (#827)`** — Spec 04 task 4.0 scope
2. **`chore: rebrand remaining devops-bootcamp references to engineering-bootcamp`** — follow-up sweep, previously PR #934 (closed, cherry-picked)

### Commit 1 — GitHub URL sweep (closes #827)

Replaces every `github.com/liatrio/devops-bootcamp` reference outside `docs/specs/**` (skipped: gitignored per PR #931 / task 1.0):

- `package.json` — `repository.url`, `bugs.url`, `homepage`
- `index.html` — Docsify edit URL
- Go module paths + imports across `examples/ch8/devops-{api,resources}` and 5 `examples/ch11/data-patterns/**/go.mod` files
- `examples/ch8/devops-api/go.mod` gains a `replace github.com/liatrio/engineering-bootcamp/examples/ch7/devops-resources => ../devops-resources` directive — the old pinned commit hash `v0.0.0-20230921193819-569bb9d9dbdd` for the sibling module is not resolvable on the renamed remote; these examples run locally.
- `examples/ch8/devops-api/go.sum` regenerated via `go mod tidy`
- `examples/codeQuality/goExamples/example_test.go` — test data URLs
- Chapter 5/6/7/8/9/11 doc pages — clone URL references
- `.github/prompts/new-section.prompt.md`

### Commit 2 — Remaining `devops-bootcamp` string cleanup

Follow-up sweep of everything Spec 99 / task 4.0 intentionally deferred:

- **Bare repo slugs** — `index.html` Docsify `repo:` config (drives "Edit on GitHub" corner button) + `catalog-info.yaml` Backstage entity name + `project-slug` annotation.
- **Terraform provider rename** (ch8 exercise) — provider address `liatr.io/terraform/devops-bootcamp` → `liatr.io/terraform/engineering-bootcamp`; binary name + plugin-cache path in `examples/ch8/provider-setup/Makefile`; matching quiz answer in `chapter-8/8.1.4/provider-name-checkpoint.js`. Also fixes a pre-existing typo `liatri.io` → `liatr.io` in the same quiz file (was a typo in only the quiz; the doc always had `liatr.io`).
- **Site-visible domain links** — swept all `devops-bootcamp.liatr.io` URLs in quiz feedback (~20 hits across 5 quiz files), one prose link in `6.5.2-functional-testing.md`, and `examples/codeQuality/selenium-frame.py`. Host swap only; paths + fragments preserved.
- **Raw content includes** — 3 pinned-SHA `raw.githubusercontent.com/liatrio/devops-bootcamp/<sha>/...` include URLs in `6.5.4-code-coverage.md`. Verified new URLs return `HTTP 200`.
- **Test fixtures + paired docs** — repo-name literals in `examples/codeQuality/goExamples/example_test.go`, `examples/codeQuality/jest-mock/mock.js`, JSDoc in `github.js`, and the paired code fences in `6.5.1-unit-testing.md`. Cherry-pick merge resolved both `Repository` and `Url` fields to `engineering-bootcamp` (also satisfies CodeRabbit finding on `example_test.go` and `6.5.1-unit-testing.md`).
- **Prose oversights** — `docs/README.md:1749-1750` docker commands (Spec 99 renamed the same commands in `CLAUDE.md` but missed this copy), `examples/ch8/devops-resources/README.md:76`, `docs/3-AI-Engineering/3.3.1-agentic-best-practices.md:52`, `examples/ch7/helm/DKS/templates/NOTES.txt:1`.

## Why

Repo was renamed `liatrio/devops-bootcamp` → `liatrio/engineering-bootcamp`. Goal: stop presenting the old brand internally. `devops-bootcamp.liatr.io` DNS still redirects to `engineering-bootcamp.liatr.io` at the Liatrio-owned DNS layer, so third-party bookmarks keep working — `CNAME` is intentionally preserved.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Zero remaining old-URL references outside `docs/specs/**` | `grep -rE 'github\.com/liatrio/devops-bootcamp' . --exclude-dir=node_modules --exclude-dir=.git \| grep -v '^\./docs/specs/'` | Empty |
| Go build + test — `devops-api` | `cd examples/ch8/devops-api && go build ./... && go test ./...` | Build: no output. Tests: `ok  devops-api  0.176s` |
| Go build — `devops-resources` | `cd examples/ch8/devops-resources && go build ./...` | No output (pass) |
| Markdown lint | `npm run lint` | `Summary: 0 issues in 0 files` (173 files) |
| Front-matter master | `npm run refresh-front-matter && git diff docs/README.md` | Diff limited to intentional lines 1749-1750 (docker commands) |
| Raw-content includes still resolve | `curl -sI` on each of the 3 rewritten URLs in `6.5.4-code-coverage.md` | `HTTP 200` on all three |
| No unintended `devops-bootcamp` left | `grep -rniE 'devops[- ]bootcamp' . --exclude-dir=node_modules --exclude-dir=.git \| grep -v '^\./docs/specs/'` | Only intentional leftovers (see below) |

## Response to CodeRabbit review (PR #934, cherry-picked here)

- **Finding 1 (`3.3.1-agentic-best-practices.md:52` — H3 heading)**: **Skipped.** The file uses `**Bold Label:**` uniformly for 4th-level headings inside H3 sections (~40 occurrences). Changing just line 52 would be inconsistent with the rest of the file's authoring convention. Repo-wide style-guide change is out of scope for this rename PR.
- **Finding 2 (`6.5.1-unit-testing.md:89/117` + `6.5.2-functional-testing.md:56` — learning-example URLs)**: **Partially addressed.** The two `6.5.1-unit-testing.md` sites were fixed in the cherry-pick merge resolution (both `Repository` and `Url` now `engineering-bootcamp`). The `6.5.2-functional-testing.md:56` site is `raw.githubusercontent.com/PaulDHenson/devops-bootcamp/...` — that's an external contributor's fork, not a Liatrio-owned URL. Left untouched.
- **Finding 3 (`example_test.go:10/32` + `devops-resources/README.md:10/20` — repository slug)**: **Addressed.** `example_test.go` URLs fixed via merge resolution. `devops-resources/README.md` lines 10 + 20 were already updated by commit 1 (task 4.0 URL sweep).

## Files explicitly NOT touched

- `CNAME` — DNS handles the redirect.
- `docs/1-introduction/1.1-devops-defined.md:17` — `OSU DevOps Bootcamp` external citation.
- `docs/6-software-development-practices/6.5.2-functional-testing.md:56` — `PaulDHenson/devops-bootcamp` external fork URL.
- `docs/9-kubernetes-container-orchestration/9.7.1-validating-admission-policy.md:52`, `9.9-controllers.md:65` — captured shell prompts `➜  devops-bootcamp ✗ ...` (historical terminal output, not branding).
- `docs/specs/**` — gitignored after PR #931 merges; out of scope.

## Notes on scope deviations from Spec 04 task list

- Chapter 9 files updated in commit 1 were `9.2`, `9.5`, `9.7`, `9.9` (task plan mentioned `9.6/9.8` — grep is authoritative).
- 5 additional `examples/ch11/data-patterns/**/go.mod` files needed updating, missed in the original task inventory. Task 4.13's zero-match acceptance gate is the source of truth.

## Spec

Spec 04 — [`04-spec-issues-and-deps-cleanup`](https://github.com/liatrio/engineering-bootcamp/blob/master/docs/specs/04-spec-issues-and-deps-cleanup/04-spec-issues-and-deps-cleanup.md), task 4.0. Also finishes work deferred by Spec 99 (`99-spec-bootcamp-rename`).

Closes #827
