### PR TITLE
chore: rebrand remaining devops-bootcamp references to engineering-bootcamp

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,9 +1,9 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: devops-bootcamp
+  name: engineering-bootcamp
   annotations:
-    github.com/project-slug: liatrio/devops-bootcamp
+    github.com/project-slug: liatrio/engineering-bootcamp
 spec:
   type: documentation
   lifecycle: production

--- a/docs/3-AI-Engineering/3.3.1-agentic-best-practices.md
+++ b/docs/3-AI-Engineering/3.3.1-agentic-best-practices.md
@@ -49,7 +49,7 @@ The first stage of Spec-Driven Development transforms a high-level idea into a c
 
 Use a conversational LLM to iteratively refine your idea through a question-based dialogue. The AI should ask one question at a time, building on your previous answers to extract every relevant detail.
 
-**Example Spec Generation Prompt** (adapted for DevOps Bootcamp):
+**Example Spec Generation Prompt** (adapted for Engineering Bootcamp):
 
 ```text
 I need to create a specification for a DevOps automation project. Ask me one question at a time to develop a thorough, step-by-step spec.

--- a/docs/6-software-development-practices/6.5.1-unit-testing.md
+++ b/docs/6-software-development-practices/6.5.1-unit-testing.md
@@ -86,7 +86,7 @@ func TestIndexGitHubRepositoriesByOrg_basic(t *testing.T) {
  repos := []*GitHubRepository{
   {
    Organization: "liatrio",
-   Repository: "devops-bootcamp",
+   Repository: "engineering-bootcamp",
    Url: "https://github.com/liatrio/devops-bootcamp",
    License: "MIT",
   },
@@ -113,7 +113,7 @@ func TestIndexGitHubRepositoriesByOrg_multiple(t *testing.T) {
  repos := []*GitHubRepository{
   {
    Organization: "liatrio",
-   Repository: "devops-bootcamp",
+   Repository: "engineering-bootcamp",
    Url: "https://github.com/liatrio/devops-bootcamp",
    License: "MIT",
   },

--- a/docs/6-software-development-practices/6.5.2-functional-testing.md
+++ b/docs/6-software-development-practices/6.5.2-functional-testing.md
@@ -48,7 +48,7 @@ We will use Selenium and Python to run a couple functional tests on the bootcamp
 ?> If you are getting an error when trying to install the Selenium Python bindings, look into [installing the packages in a virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
 
 3. Use the starter code provided to test
-    * The link in the bottom right corner of the homepage takes you to [the bootcamp introduction](https://devops-bootcamp.liatr.io/#/1-introduction/1.0-overview)
+    * The link in the bottom right corner of the homepage takes you to [the bootcamp introduction](https://engineering-bootcamp.liatr.io/#/1-introduction/1.0-overview)
     * The sidebar toggle button properly hides the sidebar
 
 ?> Note: the starter code has Firefox selected as the driver. Make sure to either change it or install geckodriver.

--- a/docs/6-software-development-practices/6.5.4-code-coverage.md
+++ b/docs/6-software-development-practices/6.5.4-code-coverage.md
@@ -22,11 +22,11 @@ You will be using [Jest](https://jestjs.io/) to test the code coverage in the pr
 
 The following code is a series of functions written in Javascript (simple.js):
 
-[sampleCode](https://raw.githubusercontent.com/liatrio/devops-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/simple.js ':include :type=code javascript')
+[sampleCode](https://raw.githubusercontent.com/liatrio/engineering-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/simple.js ':include :type=code javascript')
 
 The following code contains the unit tests that will be testing the Javascript functions (simple.test.js):
 
-[testCode](https://raw.githubusercontent.com/liatrio/devops-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/simple.test.js ':include :type=code javascript')
+[testCode](https://raw.githubusercontent.com/liatrio/engineering-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/simple.test.js ':include :type=code javascript')
 
 Please perform the following:
 
@@ -45,7 +45,7 @@ Try redoing the previous steps, but install the files as a developer dependency.
 
 The provided Javascript package.json file will have everything you need in order to pass the Jest tests; however, you will need to add to the file in order to get Jest to check your coverage.
 
-[package](https://raw.githubusercontent.com/liatrio/devops-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/package.json ':include :type=code json')
+[package](https://raw.githubusercontent.com/liatrio/engineering-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/package.json ':include :type=code json')
 
 Inside your package.json file under the “scripts” section, add a section called “coverage” and use the following command
 

--- a/docs/8-infrastructure-configuration-management/8.3-terraform-providers.md
+++ b/docs/8-infrastructure-configuration-management/8.3-terraform-providers.md
@@ -133,7 +133,7 @@ Creating a Terraform provider is hard. To help mitigate some of the difficulty, 
 1. Create your own repo containing the Hashicorp provided boilerplate code from their template.
     - To do this, navigate to the [terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding-framework) repo, click "Use this template", "Create a new repository", and fill in the required information (owner and repo name). If you're working as a group on this, make sure to also add each group member as a collaborator.
 
-2. Clone your repo. Navigate to `main.go` and change the provider address from `registry.terraform.io/hashicorp/scaffolding` to `liatr.io/terraform/devops-bootcamp`.
+2. Clone your repo. Navigate to `main.go` and change the provider address from `registry.terraform.io/hashicorp/scaffolding` to `liatr.io/terraform/engineering-bootcamp`.
 
 <div class="quizdown">
     <div id="chapter-8/8.1.4/provider-name-checkpoint.js" ></div>
@@ -153,13 +153,13 @@ Creating a Terraform provider is hard. To help mitigate some of the difficulty, 
 ```go
     terraform {
       required_providers {
-        devops-bootcamp = {
-          source = "liatr.io/terraform/devops-bootcamp"
+        engineering-bootcamp = {
+          source = "liatr.io/terraform/engineering-bootcamp"
         }
       }
     }
 
-    provider "devops-bootcamp" {
+    provider "engineering-bootcamp" {
       # example configuration here
     }
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1746,8 +1746,8 @@ Use Docker to build and serve the content, but remember to rebuild the Docker im
 
 #### Build and Run Docker Container
 
-1. Execute `docker build . -t devops-bootcamp` from the project's root directory to generate a container image
-2. Run `docker run -d -p 3000:3000 --name devops-bootcamp devops-bootcamp` to run a detached Docker container
+1. Execute `docker build . -t engineering-bootcamp` from the project's root directory to generate a container image
+2. Run `docker run -d -p 3000:3000 --name engineering-bootcamp engineering-bootcamp` to run a detached Docker container
 3. Open <http://localhost:3000>
 
 #### Docker Compose

--- a/examples/ch7/helm/DKS/templates/NOTES.txt
+++ b/examples/ch7/helm/DKS/templates/NOTES.txt
@@ -1,4 +1,4 @@
-DevOps Bootcamp: Anything in this notes file will be displayed when installing this Helm chart
+Engineering Bootcamp: Anything in this notes file will be displayed when installing this Helm chart
 
 1. Once you have all three pods running successfully you will need to run the following command:
 kubectl port-forward svc/backend 8080:8080

--- a/examples/ch8/devops-resources/README.md
+++ b/examples/ch8/devops-resources/README.md
@@ -73,4 +73,4 @@ type DevOps struct {
 ### Why is the module name long and almost looks like a path.
 
 - Go looks for the path in which the package and module is referenced.
-- For this case the repository is github.com(host)/liatrio(owner)/devops-bootcamp(repo)/examples/ch8/devops-resources(path to package)
+- For this case the repository is github.com(host)/liatrio(owner)/engineering-bootcamp(repo)/examples/ch8/devops-resources(path to package)

--- a/examples/ch8/provider-setup/Makefile
+++ b/examples/ch8/provider-setup/Makefile
@@ -7,7 +7,7 @@ GOARCH?=$$(go env GOARCH)
 plan: clean init provider resource datasource debug-allCombined
 
 build: main.go generate
-	go $@ -o terraform-provider-devops-bootcamp
+	go $@ -o terraform-provider-engineering-bootcamp
 
 debug-allCombined:
 	terraform -chdir=examples/allCombined init -plugin-dir=../../.plugin-cache
@@ -31,11 +31,11 @@ fmt: main.tf
 
 #makes a directory including making gome directories should they not exist (-p)
 init: clean build
-	@mkdir -p .plugin-cache/liatr.io/terraform/devops-bootcamp/0.0.1/$(GOOS)_$(GOARCH) && \
-	ln -s "${PWD}/terraform-provider-devops-bootcamp" "${PWD}/.plugin-cache/liatr.io/terraform/devops-bootcamp/0.0.1/$(GOOS)_$(GOARCH)/terraform-provider-devops-bootcamp"
+	@mkdir -p .plugin-cache/liatr.io/terraform/engineering-bootcamp/0.0.1/$(GOOS)_$(GOARCH) && \
+	ln -s "${PWD}/terraform-provider-engineering-bootcamp" "${PWD}/.plugin-cache/liatr.io/terraform/engineering-bootcamp/0.0.1/$(GOOS)_$(GOARCH)/terraform-provider-engineering-bootcamp"
 
 clean: 
-	@rm -rf .plugin-cache .terraform .terraform.lock.hcl terraform-provider-devops-bootcamp && \
+	@rm -rf .plugin-cache .terraform .terraform.lock.hcl terraform-provider-engineering-bootcamp && \
 	rm -rf examples/*/*/.terraform* examples/*/.terraform*
 
 provider:

--- a/examples/codeQuality/goExamples/example_test.go
+++ b/examples/codeQuality/goExamples/example_test.go
@@ -7,7 +7,7 @@ func TestIndexGitHubRepositoriesByOrg_basic(t *testing.T) {
     repos := []*GitHubRepository{
         {
             Organization: "liatrio",
-            Repository: "devops-bootcamp",
+            Repository: "engineering-bootcamp",
             Url: "https://github.com/liatrio/devops-bootcamp",
             License: "MIT",
         },
@@ -29,7 +29,7 @@ func TestIndexGitHubRepositoriesByOrg_multiple(t *testing.T) {
     repos := []*GitHubRepository{
         {
             Organization: "liatrio",
-            Repository: "devops-bootcamp",
+            Repository: "engineering-bootcamp",
             Url: "https://github.com/liatrio/devops-bootcamp",
             License: "MIT",
         },

--- a/examples/codeQuality/jest-mock/github.js
+++ b/examples/codeQuality/jest-mock/github.js
@@ -3,7 +3,7 @@ const { Octokit } = require("octokit");
 /**
  * Fetches public repository info using Octokit.
  * @param {string} owner - The repo owner (e.g., 'liatrio')
- * @param {string} repo - The repo name (e.g., 'devops-bootcamp')
+ * @param {string} repo - The repo name (e.g., 'engineering-bootcamp')
  * @returns {Promise<object>} - The repository info object
  */
 async function getRepoInfo(owner, repo) {

--- a/examples/codeQuality/jest-mock/mock.js
+++ b/examples/codeQuality/jest-mock/mock.js
@@ -40,9 +40,9 @@ async function checkUserName(username, expectedName = "Chris Blackburn") {
   }
 }
 
-//// REPO CHECKS FOR DEVOPS-BOOTCAMP ////
+//// REPO CHECKS FOR ENGINEERING-BOOTCAMP ////
 
-async function checkRepoName(owner, repo, expectedName = "devops-bootcamp") {
+async function checkRepoName(owner, repo, expectedName = "engineering-bootcamp") {
   try {
     const repoInfo = await getRepoInfo(owner, repo);
     if (!repoInfo || !repoInfo.name) {

--- a/examples/codeQuality/selenium-frame.py
+++ b/examples/codeQuality/selenium-frame.py
@@ -9,7 +9,7 @@ class LiatrioBootcampLinkTest(unittest.TestCase):
 
     def test_bootcamp_link(self):
         driver = self.driver
-        driver.get("https://devops-bootcamp.liatr.io")
+        driver.get("https://engineering-bootcamp.liatr.io")
         # check we get expected page title
 
         # find the link to Introduction to DevOps section at the bottom of the page
@@ -28,7 +28,7 @@ class LiatrioBootcampSidebarTest(unittest.TestCase):
 
     def test_bootcamp_sidebar(self):
         driver = self.driver
-        driver.get("https://devops-bootcamp.liatr.io")
+        driver.get("https://engineering-bootcamp.liatr.io")
         # check that the sidebar is shown (HINT: check html body attributes)
 
         # check that there is no CLOSE attribute on the body

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         <script>
             window.$docsify = {
                 name: "Liatrio's Engineering Bootcamp",
-                repo: "liatrio/devops-bootcamp",
+                repo: "liatrio/engineering-bootcamp",
                 loadSidebar: true,
                 basePath: "/docs/",
                 maxLevel: 0,

--- a/src/quizzes/chapter-4/4.4/docker-quiz.js
+++ b/src/quizzes/chapter-4/4.4/docker-quiz.js
@@ -15,9 +15,9 @@ shuffleAnswers: true
 1. [x] A container is a runtime instance of an image
 	> Good. The image is what defines the container and the container is what is actually running
 1. [ ] An image is a runtime instance of a container
-	> Not quite. Refer back to the [Images and Containers](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=images-and-containers) section above
+	> Not quite. Refer back to the [Images and Containers](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=images-and-containers) section above
 1. [ ] The two terms can be used interchangeably
-	> Not quite. Refer back to the [Images and Containers](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=images-and-containers) section above
+	> Not quite. Refer back to the [Images and Containers](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=images-and-containers) section above
 
 # 1/2 - Suppose you need a very specific set of dependencies and packages installed to your container, but no base image exists that has them already installed for you. What problems does this pose? Select all that apply
 
@@ -46,7 +46,7 @@ shuffleAnswers: true
 1. [x] True
 	> Good. This is because the image build will utilize caching to greatly speed up unchanged layers. This is one of Docker's best strengths
 1. [ ] False
-	> Not quite. Refer back to the [Layers](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=layers) section above
+	> Not quite. Refer back to the [Layers](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.4-containers?id=layers) section above
 
 # True or False: If you run the same Docker container twice, the start time will be shorter the second time around
 

--- a/src/quizzes/chapter-4/4.5.2/k8s-quiz.js
+++ b/src/quizzes/chapter-4/4.5.2/k8s-quiz.js
@@ -15,7 +15,7 @@ shuffleAnswers: true
 1. [ ] Docker, Kubernetes
 	> Keep in mind that while Kubernetes and Docker Compose handle container orchestration, all Docker does is create containers
 
-# Order the following Kubernetes resources into the correct scopes (highest scope to lowest scope)<br>If you are confused, reread the [Design](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=design) section above.
+# Order the following Kubernetes resources into the correct scopes (highest scope to lowest scope)<br>If you are confused, reread the [Design](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=design) section above.
 
 1. Cluster
 2. Node
@@ -24,7 +24,7 @@ shuffleAnswers: true
 # True or False: Making an invalid command to the Kubernetes API can run the risk of breaking resources in your cluster
 
 1. [ ] True
-	> Not quite. Refer back to the [Design](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=design) section above to get a firmer grasp on how Kubernetes handles changes to the cluster
+	> Not quite. Refer back to the [Design](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=design) section above to get a firmer grasp on how Kubernetes handles changes to the cluster
 1. [x] False
 	> Excellent! The great thing about the Kubernetes engine is that *proposed* changes (your commands) must be validated by an API server before any changes are made to etcd
 
@@ -33,7 +33,7 @@ shuffleAnswers: true
 1. [x] Deployments, Services
 	> Good. These terms are easy to mix up because they deal with similar things, so this is a good item to commit to memory
 1. [ ] Services, Deployments
-	> Not quite. These terms are easy to mix up because they deal with similar things, so don't sweat it. Reread the [Services](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=services) and [Deployments](https://devops-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=deployments) definitions above to help commit these to memory
+	> Not quite. These terms are easy to mix up because they deal with similar things, so don't sweat it. Reread the [Services](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=services) and [Deployments](https://engineering-bootcamp.liatr.io/#/4-virtual-machines-containers/4.5.2-kubernetes?id=deployments) definitions above to help commit these to memory
 
 `;
 

--- a/src/quizzes/chapter-5/5.1.1/aws-quiz.js
+++ b/src/quizzes/chapter-5/5.1.1/aws-quiz.js
@@ -9,9 +9,9 @@ shuffleAnswers: true
 1. [x] True
 	> Good. While naming seems like a feature that should be standalone and separate from tags, this A) allows for quick searching of resources and B) allows for a standardized naming method across all resources, regardless of their type
 1. [ ] False
-	> Not quite. Reread the [Names](https://devops-bootcamp.liatr.io/#/5-cloud-computing/5.1.1-aws?id=names) section above
+	> Not quite. Reread the [Names](https://engineering-bootcamp.liatr.io/#/5-cloud-computing/5.1.1-aws?id=names) section above
 
-# From the following list, select all *quality* resource tags<br>If you are confused, refer to [Liatrio's tagging standards](https://devops-bootcamp.liatr.io/#/5-cloud-computing/5.1.1-aws?id=liatrio39s-tagging-standards) above.
+# From the following list, select all *quality* resource tags<br>If you are confused, refer to [Liatrio's tagging standards](https://engineering-bootcamp.liatr.io/#/5-cloud-computing/5.1.1-aws?id=liatrio39s-tagging-standards) above.
 
 - [x] **Owner**=chris-blackburn
 - [x] **Project**=pipeline-initiative

--- a/src/quizzes/chapter-5/5.1.2/azure-quiz.js
+++ b/src/quizzes/chapter-5/5.1.2/azure-quiz.js
@@ -20,7 +20,7 @@ shuffleAnswers: true
 # True or False: You can change the name of a resource in Azure at any time without needing to alter the resource itself.
 
 1. [ ] True
-	> Not quite. Resource names in Azure are immutable by design, meaning they shouldn't/can't be changed. Refer back to the [Resource Naming and Tagging](https://devops-bootcamp.liatr.io/#/4-cloud-computing/4.1.2-azure?id=resource-naming-and-tagging) section above
+	> Not quite. Resource names in Azure are immutable by design, meaning they shouldn't/can't be changed. Refer back to the [Resource Naming and Tagging](https://engineering-bootcamp.liatr.io/#/4-cloud-computing/4.1.2-azure?id=resource-naming-and-tagging) section above
 1. [x] False
 	> Good. Since resource names are immutable, you would need to destroy the resource and recreate it with a different name
 

--- a/src/quizzes/chapter-5/5.2.2/ec2-and-jenkins-quiz.js
+++ b/src/quizzes/chapter-5/5.2.2/ec2-and-jenkins-quiz.js
@@ -52,11 +52,11 @@ shuffleAnswers: true
 1. [x] Controller, Agent
 	> Good. The controller is the original node that delegates work to one or multiple agents
 1. [ ] Agent, Controller
-	> Almost there! Refer back to the [Jenkins Architecture](https://devops-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
+	> Almost there! Refer back to the [Jenkins Architecture](https://engineering-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
 1. [ ] Pipeline, Agent
-	> Not quite. The Jenkins Pipeline refers to the entire process as a whole. Refer back to the [Jenkins Architecture](https://devops-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
+	> Not quite. The Jenkins Pipeline refers to the entire process as a whole. Refer back to the [Jenkins Architecture](https://engineering-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
 1. [ ] Pipeline, Controller
-	> Not quite. The Jenkins Pipeline refers to the entire process as a whole. Refer back to the [Jenkins Architecture](https://devops-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
+	> Not quite. The Jenkins Pipeline refers to the entire process as a whole. Refer back to the [Jenkins Architecture](https://engineering-bootcamp.liatr.io/#/4-cloud-computing/4.2.2-ec2?id=jenkins) above
 
 # True or False: You can have agents working together and running in unison across different environments in one Jenkins pipeline
 

--- a/src/quizzes/chapter-8/8.1.4/provider-name-checkpoint.js
+++ b/src/quizzes/chapter-8/8.1.4/provider-name-checkpoint.js
@@ -2,11 +2,11 @@ const rawQuizdown = `
 ---
 shuffleAnswers: true
 ---
-# Based on the provider address \`\`\`liatri.io/terraform/devops-bootcamp\`\`\`, what is the name of your provider?
+# Based on the provider address \`\`\`liatr.io/terraform/engineering-bootcamp\`\`\`, what is the name of your provider?
 
-- [x] devops-bootcamp
-- [ ] liatri.io/terraform/devops-bootcamp
-- [ ] liatri.io
+- [x] engineering-bootcamp
+- [ ] liatr.io/terraform/engineering-bootcamp
+- [ ] liatr.io
 `;
 
 export { rawQuizdown }


### PR DESCRIPTION
## What Changed

Follow-up sweep to clean up every remaining `devops-bootcamp` string a website visitor or exercise-follower would see. Spec 99 (repo rename) and PR #933 (task 4.0, `github.com/liatrio/devops-bootcamp` URL sweep) each intentionally deferred these cases; this PR closes out the tail.

- **Bare repo slugs** — `index.html` Docsify `repo:` config (drives "Edit on GitHub" corner button) + `catalog-info.yaml` Backstage entity name + `project-slug` annotation.
- **Terraform provider rename** (ch8 exercise) — provider address `liatr.io/terraform/devops-bootcamp` → `liatr.io/terraform/engineering-bootcamp`; binary name + plugin-cache path in `examples/ch8/provider-setup/Makefile`; matching quiz answer in `chapter-8/8.1.4/provider-name-checkpoint.js`. Also fixes a pre-existing typo `liatri.io` → `liatr.io` in the same quiz file (was a typo in only the quiz; the doc always had `liatr.io`).
- **Site-visible domain links** — swept all `devops-bootcamp.liatr.io` URLs in quiz feedback (~20 hits across 5 quiz files), one prose link in `6.5.2-functional-testing.md`, and `examples/codeQuality/selenium-frame.py`. Host swap only; paths + fragments preserved.
- **Raw content includes** — 3 pinned-SHA `raw.githubusercontent.com/liatrio/devops-bootcamp/<sha>/...` include URLs in `6.5.4-code-coverage.md`. Verified new URLs return 200 (see Verification).
- **Test fixtures + paired docs** — repo-name literals in `examples/codeQuality/goExamples/example_test.go`, `examples/codeQuality/jest-mock/mock.js`, JSDoc in `github.js`, and the paired code fences in `6.5.1-unit-testing.md`.
- **Prose oversights** — `docs/README.md:1749-1750` docker commands (spec 99 renamed the same commands in `CLAUDE.md` but missed this copy), `examples/ch8/devops-resources/README.md:76`, `docs/3-AI-Engineering/3.3.1-agentic-best-practices.md:52`, `examples/ch7/helm/DKS/templates/NOTES.txt:1`.

## Why

Repo was renamed `liatrio/devops-bootcamp` → `liatrio/engineering-bootcamp`. Everything the user asked for is content that would look like a stale artifact to a visitor or exercise-follower. This is NOT a backwards-compat concern: `devops-bootcamp.liatr.io` DNS still redirects to `engineering-bootcamp.liatr.io` at the Liatrio-owned DNS layer, so third-party bookmarks keep working. Goal is to stop presenting the old brand internally.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Markdown lint | `npm run lint` | `Summary: 0 issues in 0 files` (173 files) |
| Front-matter master | `npm run refresh-front-matter && git diff docs/README.md` | Diff limited to intentional lines 1749-1750 (docker commands) |
| Raw-content includes still resolve | `curl -sI` on each of the 3 rewritten URLs in `6.5.4-code-coverage.md` | `HTTP 200` on all three |
| No unintended `devops-bootcamp` left | `grep -rniE 'devops[- ]bootcamp' . --exclude-dir=node_modules --exclude-dir=.git \| grep -v '^\./docs/specs/'` | Only expected leftovers (see "Explicitly not touched" below) |

**Not gated:** `go test` in `examples/codeQuality/goExamples` — that directory has no `go.mod` (it's illustrative source, not a runnable module). The `Repository:` field is a `struct` literal in test data; changing the string can't fail compilation or the test assertions (which key on `Organization`).

**Terraform provider `make init` not run** — requires terraform + go toolchain and a template repo clone that's outside scope; the Makefile edits are pure string swaps with no path-computation changes.

## Files explicitly NOT touched

- `CNAME` — DNS handles the redirect (per user).
- `docs/1-introduction/1.1-devops-defined.md:17` — `OSU DevOps Bootcamp` external citation.
- `docs/6-software-development-practices/6.5.2-functional-testing.md:56` — `PaulDHenson/devops-bootcamp` external fork URL.
- `docs/9-kubernetes-container-orchestration/9.7.1-validating-admission-policy.md:52`, `9.9-controllers.md:65` — captured shell prompts `➜  devops-bootcamp ✗ ...` (historical terminal output, not branding).
- `github.com/liatrio/devops-bootcamp` URL form — owned by PR #933 (task 4.0); this branch was cut from `master` before that merges, so those hits are absent from this diff.

## Spec

Follow-up to Spec 99 (`99-spec-bootcamp-rename`) and Spec 04 / task 4.0 (PR #933). No new spec authored — this is finishing work explicitly deferred by both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the bootcamp name throughout documentation, examples, quizzes, and setup instructions to “Engineering Bootcamp.”
  * Updated repository, website, provider, Docker image, and external links to use the new naming.

* **Configuration**
  * Updated catalog and repository integrations to reference the Engineering Bootcamp project.

* **Tests**
  * Updated test fixtures, navigation targets, and expected repository names to match the new project identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->