### PR TITLE
Fix CloudFront origin domain name syntax

### DIFF
--- a/docs/5-cloud-computing/5.2.1-s3-cloudfront.md
+++ b/docs/5-cloud-computing/5.2.1-s3-cloudfront.md
@@ -87,7 +87,7 @@ deployed, and create an alias Record Set to forward traffic from a subdomain usi
 1. Create the CloudFront Distribution. This command specifies what URL and root object to use as the origin for the web distribution. Then take note of the created distribution's ARN, Domain Name, ID, and ETag that the command outputs. The ARN can be used to add tags, the domain name is where you can reach your distribution on the web, and the ID and ETag are used to delete the distribution.
 
 ```bash
-aws cloudfront create-distribution --origin-domain-name YOUR_NAME-dob-react.s3-website-us-west-2.amazonaws.com --default-root-object index.html
+aws cloudfront create-distribution --origin-domain-name YOUR_NAME-dob-react.s3-website.us-west-2.amazonaws.com --default-root-object index.html
 ```
 
 2. Navigate to the outputted CloudFront Domain Name to view your S3 content now distributed using a Web Distribution. This enables your S3 content to be accessible as fast as possible for users.


### PR DESCRIPTION
Correct the origin domain name format for CloudFront distribution creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CloudFront distribution setup command shown in Exercise 2.
  * Preserved the existing origin and default root object parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->