### PR TITLE
change: snippets in `docs/5-cloud-computing /5.2.1-s3-cloudfront.md` to be more directly executable

### DIFF
--- a/docs/5-cloud-computing/5.2.1-s3-cloudfront.md
+++ b/docs/5-cloud-computing/5.2.1-s3-cloudfront.md
@@ -41,27 +41,31 @@ For this exercise we're hosting a static HTML website using AWS S3. We will be u
 5. Create the S3 Bucket. Replace *YOUR_NAME* with your name and *PROFILE_NAME* with the name of the AWS cli profile you set up. Make sure to replace *PROFILE_REGION* with the region you configured your AWS cli profile to talk to (run `cat ~/.aws/config` to see what your cli is configured to).
 
 ```bash
-aws s3api create-bucket --bucket YOUR_NAME-dob-react --create-bucket-configuration LocationConstraint=PROFILE_REGION.
+# Define your variables first
+YOUR_NAME='<YOUR_NAME>'            # e.g. "EMAN RUOY"
+PROFILE_REGION='<PROFILE_REGION>'  # e.g. "us-east-2"
+
+aws s3api create-bucket --bucket "${YOUR_NAME}-dob-react" --create-bucket-configuration "LocationConstraint=${PROFILE_REGION}"
 ```
 
 6. Verify that the S3 bucket was created in the AWS console.
 7. Configure the Bucket for Static Website Hosting. This command specifies the bucket as one that hosts static website content as well as specifies which files to be used for the home page and error page. Don't forget to change the *YOUR_NAME* and *PROFILE_NAME* values.
 
 ```bash
-aws s3 website s3://YOUR_NAME-dob-react --index-document index.html --error-document 405.html
+aws s3 website "s3://${YOUR_NAME}-dob-react" --index-document index.html --error-document 405.html
 ```
 
 8. Add tags to the S3 Bucket. While tagging resources is an optional feature in AWS, it is an important organization habit to get into.
 
 ```bash
-aws s3api put-bucket-tagging --bucket YOUR_NAME-dob-react --tagging 'TagSet=[{Key=Client,Value=Internal},{Key=Project,Value=DOB},{Key=Environment,Value=Demo},{Key=Application,Value=React},{Key=Owner,Value=YOUR_NAME}]'
+aws s3api put-bucket-tagging --bucket "${YOUR_NAME}-dob-react" --tagging "TagSet=[{Key=Client,Value=Internal},{Key=Project,Value=DOB},{Key=Environment,Value=Demo},{Key=Application,Value=React},{Key=Owner,Value=${YOUR_NAME}}]"
 ```
 
 9. Verify the tags were created in the AWS console.
 10. Upload the contents of the *build/* folder, which contains the HTML generated from the template, to our S3 bucket.
 
 ```bash
-aws s3 sync build/ s3://YOUR_NAME-dob-react
+aws s3 sync build/ "s3://${YOUR_NAME}-dob-react"
 ```
 
 11. Before your website will be visible to the outside world you need to allow outside traffic to access your bucket. AWS manages access control to S3 buckets via [Bucket Policies](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html). Read about bucket policies and add a policy to allow public read access.
@@ -87,14 +91,15 @@ deployed, and create an alias Record Set to forward traffic from a subdomain usi
 1. Create the CloudFront Distribution. This command specifies what URL and root object to use as the origin for the web distribution. Then take note of the created distribution's ARN, Domain Name, ID, and ETag that the command outputs. The ARN can be used to add tags, the domain name is where you can reach your distribution on the web, and the ID and ETag are used to delete the distribution.
 
 ```bash
-aws cloudfront create-distribution --origin-domain-name YOUR_NAME-dob-react.s3-website.us-west-2.amazonaws.com --default-root-object index.html
+aws cloudfront create-distribution --origin-domain-name "${YOUR_NAME}-dob-react.s3-website.${PROFILE_REGION}.amazonaws.com" --default-root-object index.html
 ```
 
 2. Navigate to the outputted CloudFront Domain Name to view your S3 content now distributed using a Web Distribution. This enables your S3 content to be accessible as fast as possible for users.
 3. Tag your Distribution using the ARN from the output of step 1.
 
 ```bash
-aws cloudfront tag-resource --resource ARN --tags 'Items=[{Key=Client,Value=Internal},{Key=Project,Value=DOB},{Key=Environment,Value=Demo},{Key=Application,Value=React},{Key=Owner,Value=YOUR_NAME}]'
+ARN='<ARN_STRING>'
+aws cloudfront tag-resource --resource "${ARN}" --tags "Items=[{Key=Client,Value=Internal},{Key=Project,Value=DOB},{Key=Environment,Value=Demo},{Key=Application,Value=React},{Key=Owner,Value=${YOUR_NAME}}]"
 ```
 
 4. Verify the tags are added to your Distribution in the AWS console.
@@ -108,38 +113,46 @@ The following commands delete all objects in the bucket, remove the bucket and d
 1. Remove all Objects from the S3 Bucket.
 
 ```bash
-aws s3 rm s3://YOUR_NAME-dob-react --recursive
+aws s3 rm "s3://${YOUR_NAME}-dob-react" --recursive
 ```
 
 2. Delete the empty S3 Bucket.
 
 ```bash
-aws s3api delete-bucket --bucket YOUR_NAME-dob-react
+aws s3api delete-bucket --bucket "${YOUR_NAME}-dob-react"
 ```
 
 3. Get the configuration for the distribution, using its ID from the command earlier, and save it to a file.
 
 ```bash
-aws cloudfront get-distribution-config --id ID > distribution-config
+aws cloudfront get-distribution-config --id "${ID}" > distribution-config
 ```
 
 4. Edit the `distribution-config` file so that it only contains the contents of the *DistributionConfig* field and change `Enabled` to false.
 5. Disable the distribution and record the ETag from the output.
 
 ```bash
-aws cloudfront update-distribution --id ID --if-match ETAG --distribution-config file://distribution-config
+aws cloudfront update-distribution --id "${ID}" --if-match "${ETAG}" --distribution-config file://distribution-config
 ```
 
 6. The distribution can not be deleted until each of the edge locations have been disabled. Check for the status `Deployed`:
 
 ```bash
-aws cloudfront get-distribution --id ID
+echo '- Waiting for status "Deployed" ...'
+while [ "$(aws cloudfront get-distribution --id "${ID}" | jq '.Distribution.Status')" != "Deployed" ]; do sleep 1; done
 ```
 
-7. Delete the Distribution using its ID and the ETag from the update-distribution command.
+7. Once the deployment is completed, the distribution has effectively been modified, and therefore has a new ETag,
+   so update the `ETAG` shell variable:
 
 ```bash
-aws cloudfront delete-distribution --id ID --if-match ETAG
+ETAG="$(aws cloudfront get-distribution --id "${ID}" | jq '.ETag' | tr -d '"')"
+```
+
+8. Delete the Distribution using its ID and the ETag from the update-distribution command.
+
+```bash
+aws cloudfront delete-distribution --id "${ID}" --if-match "${ETAG}"
 ```
 
 ## Knowledge Check


### PR DESCRIPTION
Some of the commands had ambiguities that tripped up apprentice group,
esp. use of variables that were not clearly labelled as such when introducing
a new tool (`aws` CLI) where lex/syntax is unknown/unfamiliar.

By converting instances of `VAR` to `"${VAR}"` (quoted shell-variable notation),
these ambiguities are resolved for future apprentice groups going through the bootcamp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the S3 and CloudFront lab instructions with clearer, consistently formatted CLI commands.
  * Revised local URL, bucket, website, tagging, and distribution setup examples.
  * Expanded cleanup guidance with a safer disable, deployment-wait, configuration refresh, and deletion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->