### PR TITLE
change: stackoverflow link 5.2.6-ecs.md

### DIFF
--- a/docs/5-cloud-computing/5.2.6-ecs.md
+++ b/docs/5-cloud-computing/5.2.6-ecs.md
@@ -24,7 +24,7 @@ In this section we'll be exploring the functionality and use of Amazon's Elastic
 
 ECS configures containers using Task and Service structures. Task Definitions are used to specify a collection of one or more containers. Tasks Definitions are then assigned to Services that can be used to run one or more instances of a Task. This structure allows users to easily scale and provision resources for a cluster.
 
-Checkout this great explanation: [What is the difference between a task and service?](https://stackoverflow.com/questions/5.960678/aws-ecs-what-is-the-difference-between-a-task-and-a-service)
+Checkout this great explanation: [What is the difference between a task and service?](https://stackoverflow.com/questions/42960678/what-is-the-difference-between-a-task-and-a-service-in-aws-ecs)
 
 ## Exercise
 


### PR DESCRIPTION
Old link is dead with no web.archive.org backup, and it appears to have the wrong format anyways (decimal number as question ID, should be integer, removing `.` in link leads to question about `git` commands, not ECS).

New link leads to closed stackoverflow Q/A about the same topic with 553 upvotes on the accepted answer as of 2026-08-07.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Stack Overflow reference explaining the difference between ECS tasks and services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->